### PR TITLE
Update daos with resolvers and webhook ID for prod Muse0

### DIFF
--- a/src/config/daos/daosDevelopment.ts
+++ b/src/config/daos/daosDevelopment.ts
@@ -1,5 +1,6 @@
 import {CORE_DAO_ADAPTERS} from './daoAdapters';
 import {DaoData} from '../types';
+import {legacyTributeProposalResolver} from '../../services/snapshotHub';
 
 /**
  * A DEVELOPMENT configuration mapping for DAO's this app recognises.
@@ -27,5 +28,14 @@ export const DAOS_DEVELOPMENT: Record<
     events: [{name: 'SPONSORED_PROPOSAL'}],
     friendlyName: 'Tribute DAO [DEV]',
     registryContractAddress: '0xf5af0d9c3e4091a48925902eaAB2982e44E7a4C5',
+    snapshotHub: {
+      proposalResolver: async (proposalID, space) =>
+        await legacyTributeProposalResolver({
+          apiBaseURL: 'https://snapshot-hub-erc712.dev.thelao.io/api',
+          proposalID,
+          space,
+        }),
+      space: 'tribute',
+    },
   },
 };

--- a/src/config/daos/daosLocalhost.example.ts
+++ b/src/config/daos/daosLocalhost.example.ts
@@ -45,6 +45,16 @@ export const DAOS_LOCALHOST: Record<
     events: [{name: 'SPONSORED_PROPOSAL'}],
     friendlyName: 'Tribute DAO [DEV]',
     registryContractAddress: '0x0000000000000000000000000000000000000000',
+    snapshotHub: {
+      proposalResolver: async (proposalID, space) =>
+        await legacyTributeProposalResolver({
+          // @see `docker-host` in `docker-compose.dev.yml`
+          apiBaseURL: 'http://docker-host:8081/api',
+          proposalID,
+          space,
+        }),
+      space: 'test',
+    },
   },
 };
 */

--- a/src/config/daos/daosProduction.ts
+++ b/src/config/daos/daosProduction.ts
@@ -1,5 +1,6 @@
 import {CORE_DAO_ADAPTERS} from './daoAdapters';
 import {DaoData} from '../types';
+import {legacyTributeProposalResolver} from '../../services/snapshotHub';
 
 /**
  * A PRODUCTION configuration mapping for DAO's this app recognises.
@@ -16,7 +17,9 @@ export const DAOS_PRODUCTION: Record<
   DaoData
 > = {
   muse0: {
-    actions: [{name: 'SPONSORED_PROPOSAL_WEBHOOK', webhookID: 'abc123'}],
+    actions: [
+      {name: 'SPONSORED_PROPOSAL_WEBHOOK', webhookID: '888443179039354941'},
+    ],
     adapters: {
       [CORE_DAO_ADAPTERS['tribute-nft']]: {
         friendlyName: 'tribute-nft',
@@ -27,5 +30,14 @@ export const DAOS_PRODUCTION: Record<
     events: [{name: 'SPONSORED_PROPOSAL'}],
     friendlyName: 'Muse0',
     registryContractAddress: '0x7c8B281C56f7ef9b8099D3F491AF24DC2C2e3ee0',
+    snapshotHub: {
+      proposalResolver: async (proposalID, space) =>
+        await legacyTributeProposalResolver({
+          apiBaseURL: 'https://snapshot-hub-erc712.thelao.io/api',
+          proposalID,
+          space,
+        }),
+      space: 'museo',
+    },
   },
 };


### PR DESCRIPTION
✨ **Updates**

- Adds `snapshotHub.proposalResolver` for development and production daos
- Adds actual `webhookID` for production `muse0`


