### PR TITLE
Uses `node:16-alpine` for `Dockerfile.dev`

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,9 @@
 # `Dockerfile` for local development using Docker Compose.
 ##
 
-FROM node:16
+FROM node:16-alpine
+# Add `bash` to alpine to run our shell scripts
+RUN apk add --no-cache bash
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci


### PR DESCRIPTION
Produces a much smaller container (over 50% smaller!) for local development.

🧹 **Chores done**

- Uses `node:16-alpine` in `Dockerfile.dev`
- Installs `bash` in `Dockerfile.dev`
