### PR TITLE
Implements Snapshot Hub draft submissions -> Discord webhook

### DIFF
--- a/src/config/daos/daosDevelopment.ts
+++ b/src/config/daos/daosDevelopment.ts
@@ -1,6 +1,6 @@
 import {
-  legacyTributeProposalResolver,
   SnapshotHubProposalResolverArgs,
+  snapshotHubResolverSelector,
 } from '../../services/snapshotHub';
 import {BURN_ADDRESS} from '../../helpers';
 import {CORE_DAO_ADAPTERS} from './daoAdapters';
@@ -49,20 +49,10 @@ export const DAOS_DEVELOPMENT: Record<
       proposalResolver: async <R = any>(
         args: SnapshotHubProposalResolverArgs
       ) => {
-        const {resolver} = args;
-
-        const DEFAULT_ARGS = {
+        return snapshotHubResolverSelector<R>({
           ...args,
           apiBaseURL: 'https://snapshot-hub-erc712.dev.thelao.io/api',
-        };
-
-        switch (resolver) {
-          case 'LEGACY_TRIBUTE':
-            return await legacyTributeProposalResolver<R>(DEFAULT_ARGS);
-
-          default:
-            return await legacyTributeProposalResolver<R>(DEFAULT_ARGS);
-        }
+        });
       },
       space: 'tribute',
     },

--- a/src/config/daos/daosDevelopment.ts
+++ b/src/config/daos/daosDevelopment.ts
@@ -14,7 +14,7 @@ import {DaoData} from '../types';
  * exported mapping below.
  */
 
-export const DAO_NAMES_DEVELOPMENT = ['tribute'] as const;
+export const DAO_NAMES_DEVELOPMENT = ['muse0', 'tribute'] as const;
 
 export const DAOS_DEVELOPMENT: Record<
   typeof DAO_NAMES_DEVELOPMENT[number],
@@ -55,6 +55,44 @@ export const DAOS_DEVELOPMENT: Record<
         });
       },
       space: 'tribute',
+    },
+  },
+
+  muse0: {
+    actions: [
+      {
+        name: 'SPONSORED_PROPOSAL_WEBHOOK',
+        webhookID: '886976872611729439',
+      },
+      {
+        name: 'SNAPSHOT_PROPOSAL_CREATED_WEBHOOK',
+        webhookID: '886976872611729439',
+      },
+    ],
+    adapters: {
+      [CORE_DAO_ADAPTERS['tribute-nft']]: {
+        friendlyName: 'tribute-nft',
+        baseURLPath: 'curation',
+      },
+      [BURN_ADDRESS]: {
+        friendlyName: 'Governance',
+        baseURLPath: 'governance',
+      },
+    },
+    baseURL: 'https://muse0.xyz',
+    events: [{name: 'SPONSORED_PROPOSAL'}, {name: 'SNAPSHOT_PROPOSAL_CREATED'}],
+    friendlyName: 'Muse0',
+    registryContractAddress: '0x7c8B281C56f7ef9b8099D3F491AF24DC2C2e3ee0',
+    snapshotHub: {
+      proposalResolver: async <R = any>(
+        args: SnapshotHubProposalResolverArgs
+      ) => {
+        return snapshotHubResolverSelector<R>({
+          ...args,
+          apiBaseURL: 'https://snapshot-hub-erc712.thelao.io/api',
+        });
+      },
+      space: 'museo',
     },
   },
 };

--- a/src/config/daos/daosDevelopment.ts
+++ b/src/config/daos/daosDevelopment.ts
@@ -16,6 +16,9 @@ import {DaoData} from '../types';
 
 export const DAO_NAMES_DEVELOPMENT = ['muse0', 'tribute'] as const;
 
+const SNAPSHOT_HUB_API_URL: string =
+  'https://snapshot-hub-erc712.dev.thelao.io/api';
+
 export const DAOS_DEVELOPMENT: Record<
   typeof DAO_NAMES_DEVELOPMENT[number],
   DaoData
@@ -51,7 +54,7 @@ export const DAOS_DEVELOPMENT: Record<
       ) => {
         return snapshotHubResolverSelector<R>({
           ...args,
-          apiBaseURL: 'https://snapshot-hub-erc712.dev.thelao.io/api',
+          apiBaseURL: SNAPSHOT_HUB_API_URL,
         });
       },
       space: 'tribute',
@@ -81,15 +84,15 @@ export const DAOS_DEVELOPMENT: Record<
     },
     baseURL: 'https://muse0.xyz',
     events: [{name: 'SPONSORED_PROPOSAL'}, {name: 'SNAPSHOT_PROPOSAL_CREATED'}],
-    friendlyName: 'Muse0',
-    registryContractAddress: '0x7c8B281C56f7ef9b8099D3F491AF24DC2C2e3ee0',
+    friendlyName: 'Muse0 [DEV]',
+    registryContractAddress: '0x00637869d068a5A5fB6fa42d7c025d1dCbd14f99',
     snapshotHub: {
       proposalResolver: async <R = any>(
         args: SnapshotHubProposalResolverArgs
       ) => {
         return snapshotHubResolverSelector<R>({
           ...args,
-          apiBaseURL: 'https://snapshot-hub-erc712.thelao.io/api',
+          apiBaseURL: SNAPSHOT_HUB_API_URL,
         });
       },
       space: 'museo',

--- a/src/config/daos/daosProduction.ts
+++ b/src/config/daos/daosProduction.ts
@@ -1,10 +1,10 @@
+import {
+  SnapshotHubProposalResolverArgs,
+  snapshotHubResolverSelector,
+} from '../../services/snapshotHub';
 import {BURN_ADDRESS} from '../../helpers';
 import {CORE_DAO_ADAPTERS} from './daoAdapters';
 import {DaoData} from '../types';
-import {
-  legacyTributeProposalResolver,
-  SnapshotHubProposalResolverArgs,
-} from '../../services/snapshotHub';
 
 /**
  * A PRODUCTION configuration mapping for DAO's this app recognises.
@@ -49,20 +49,10 @@ export const DAOS_PRODUCTION: Record<
       proposalResolver: async <R = any>(
         args: SnapshotHubProposalResolverArgs
       ) => {
-        const {resolver} = args;
-
-        const DEFAULT_ARGS = {
+        return snapshotHubResolverSelector<R>({
           ...args,
           apiBaseURL: 'https://snapshot-hub-erc712.thelao.io/api',
-        };
-
-        switch (resolver) {
-          case 'LEGACY_TRIBUTE':
-            return await legacyTributeProposalResolver<R>(DEFAULT_ARGS);
-
-          default:
-            return await legacyTributeProposalResolver<R>(DEFAULT_ARGS);
-        }
+        });
       },
       space: 'museo',
     },

--- a/src/config/snapshotHubResolvers.ts
+++ b/src/config/snapshotHubResolvers.ts
@@ -6,4 +6,5 @@ export const SNAPSHOT_HUB_RESOLVERS = [
    * `erc-712` branch in `tributelabs/snapshot-hub` fork
    */
   'LEGACY_TRIBUTE',
+  'LEGACY_TRIBUTE_DRAFT',
 ] as const;

--- a/src/services/dao/getProposalAdapterID.unit.test.ts
+++ b/src/services/dao/getProposalAdapterID.unit.test.ts
@@ -1,3 +1,4 @@
+import {BURN_ADDRESS} from '../../helpers';
 import {BYTES32_FIXTURE, ETH_ADDRESS_FIXTURE} from '../../../test';
 import {getProposalAdapterID} from './getProposalAdapterID';
 import {mockWeb3Provider} from '../../../test/setup';
@@ -22,21 +23,84 @@ describe('getProposalAdapterID unit tests', () => {
     );
 
     expect(
-      await getProposalAdapterID(
-        '0x0000000000000000000000000000000000000000000000000000000000000000',
-        '0x0000000000000000000000000000000000000000'
-      )
+      await getProposalAdapterID({
+        daoAddress: BURN_ADDRESS,
+        proposalID: BYTES32_FIXTURE,
+      })
     ).toBe(BYTES32_FIXTURE);
+  });
+
+  test('should return an adapter address when `adapterAddress` provided', async () => {
+    // Mock respsonse for `inverseAdapters`
+    mockWeb3Provider.injectResult(
+      web3.eth.abi.encodeParameters(
+        ['bytes32', 'uint256'],
+        [BYTES32_FIXTURE, 1]
+      )
+    );
+
+    expect(
+      await getProposalAdapterID({
+        daoAddress: BURN_ADDRESS,
+        adapterAddress: BURN_ADDRESS,
+      })
+    ).toBe(BYTES32_FIXTURE);
+
+    // Mock respsonse for `inverseAdapters`
+    mockWeb3Provider.injectResult(
+      web3.eth.abi.encodeParameters(
+        ['bytes32', 'uint256'],
+        [BYTES32_FIXTURE, 1]
+      )
+    );
+
+    expect(
+      await getProposalAdapterID({
+        daoAddress: BURN_ADDRESS,
+        adapterAddress: BURN_ADDRESS,
+        proposalID: BYTES32_FIXTURE,
+      })
+    ).toBe(BYTES32_FIXTURE);
+  });
+
+  test('should return `undefined` if an adapter address === `BURN_ADDRESS`', async () => {
+    // Mock respsonse for `proposals`
+    mockWeb3Provider.injectResult(
+      web3.eth.abi.encodeParameters(['address', 'uint256'], [BURN_ADDRESS, 1])
+    );
+
+    // Mock respsonse for `inverseAdapters`
+    mockWeb3Provider.injectResult(
+      web3.eth.abi.encodeParameters(
+        ['bytes32', 'uint256'],
+        [BYTES32_FIXTURE, 1]
+      )
+    );
+
+    expect(
+      await getProposalAdapterID({
+        daoAddress: BURN_ADDRESS,
+        proposalID: BYTES32_FIXTURE,
+      })
+    ).toBe(undefined);
+  });
+
+  test('should return `undefined` if an adapter address is an empty `string`', async () => {
+    expect(
+      await getProposalAdapterID({
+        daoAddress: BURN_ADDRESS,
+      })
+    ).toBe(undefined);
   });
 
   test('should throw an error when call fails', async () => {
     mockWeb3Provider.injectError({code: 1234, message: 'Some bad error'});
 
     try {
-      await getProposalAdapterID(
-        '0x0000000000000000000000000000000000000000000000000000000000000000',
-        '0x0000000000000000000000000000000000000000'
-      );
+      await getProposalAdapterID({
+        daoAddress: BURN_ADDRESS,
+        proposalID: BYTES32_FIXTURE,
+      });
     } catch (error) {
       expect((error as Error).message).toMatch(/some bad error/i);
     }

--- a/src/services/snapshotHub/index.ts
+++ b/src/services/snapshotHub/index.ts
@@ -1,3 +1,4 @@
 export * from './legacyTributeDraftResolver';
 export * from './legacyTributeProposalResolver';
+export * from './snapshotHubResolverSelector';
 export * from './types';

--- a/src/services/snapshotHub/index.ts
+++ b/src/services/snapshotHub/index.ts
@@ -1,2 +1,3 @@
+export * from './legacyTributeDraftResolver';
 export * from './legacyTributeProposalResolver';
 export * from './types';

--- a/src/services/snapshotHub/legacyTributeDraftResolver.ts
+++ b/src/services/snapshotHub/legacyTributeDraftResolver.ts
@@ -1,0 +1,66 @@
+import {
+  SnapshotHubLegacyTributeDraft,
+  SnapshotHubLegacyTributeDraftEntry,
+  SnapshotHubProposalBase,
+  SnapshotHubProposalResolverArgs,
+} from './types';
+import {fetchGetJSON} from '../../helpers';
+import {getProposalErrorHandler} from './helpers';
+
+/**
+ * Resolves a legacy Snapshot draft from a custom Tribute ERC-712 implementation.
+ *
+ * @param data `SnapshotHubProposalResolverArgs`
+ * @returns `Promise<SnapshotHubProposalBase | undefined>`
+ */
+export async function legacyTributeDraftResolver<
+  R = SnapshotHubLegacyTributeDraft
+>({
+  apiBaseURL,
+  proposalID,
+  queryString,
+  space,
+}: SnapshotHubProposalResolverArgs): Promise<
+  SnapshotHubProposalBase<R> | undefined
+> {
+  try {
+    const draft = await fetchGetJSON<SnapshotHubLegacyTributeDraftEntry>(
+      `${apiBaseURL}/${space}/draft/${proposalID}${queryString || ''}`
+    );
+
+    if (!draft) {
+      return undefined;
+    }
+
+    const raw = Object.entries(draft)[0]?.[1];
+
+    if (!raw) {
+      return undefined;
+    }
+
+    const {
+      msg: {
+        payload: {name, body},
+      },
+    } = raw;
+
+    return {
+      /**
+       * Helper
+       */
+      body,
+      id: proposalID,
+      title: name,
+      /**
+       * Raw response
+       */
+      raw: raw as any as R,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      getProposalErrorHandler({error: error, proposalID});
+    }
+
+    return undefined;
+  }
+}

--- a/src/services/snapshotHub/legacyTributeDraftResolver.unit.test.ts
+++ b/src/services/snapshotHub/legacyTributeDraftResolver.unit.test.ts
@@ -1,0 +1,91 @@
+import {
+  BYTES32_FIXTURE,
+  LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE,
+} from '../../../test';
+import {legacyTributeDraftResolver} from './legacyTributeDraftResolver';
+import {rest, server} from '../../../test/msw/server';
+import {SnapshotHubLegacyTributeProposalEntry} from '.';
+
+describe('legacyTributeDraftResolver unit tests', () => {
+  const draftData = Object.entries(
+    LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE
+  )[0][1];
+
+  test('should return a legacy Tribute snapshot hub draft', async () => {
+    expect(
+      await legacyTributeDraftResolver({
+        // @see `docker-host` in `docker-compose.dev.yml`
+        apiBaseURL: 'http://docker-host:8081/api',
+        proposalID: BYTES32_FIXTURE,
+        space: 'tribute',
+      })
+    ).toEqual({
+      body: draftData.msg.payload.body,
+      id: BYTES32_FIXTURE,
+      raw: draftData,
+      title: draftData.msg.payload.name,
+    });
+  });
+
+  test('should return `undefined` if response is empty', async () => {
+    server.use(
+      rest.get<undefined, SnapshotHubLegacyTributeProposalEntry>(
+        'http://*/api/*/draft/*',
+        (_req, res, ctx) => res(ctx.status(404))
+      )
+    );
+
+    expect(
+      await legacyTributeDraftResolver({
+        // @see `docker-host` in `docker-compose.dev.yml`
+        apiBaseURL: 'http://docker-host:8081/api',
+        proposalID: BYTES32_FIXTURE,
+        space: 'tribute',
+      })
+    ).toBe(undefined);
+
+    server.use(
+      rest.get<undefined, SnapshotHubLegacyTributeProposalEntry>(
+        'http://*/api/*/draft/*',
+        (_req, res, ctx) => res(ctx.json({}))
+      )
+    );
+
+    expect(
+      await legacyTributeDraftResolver({
+        // @see `docker-host` in `docker-compose.dev.yml`
+        apiBaseURL: 'http://docker-host:8081/api',
+        proposalID: BYTES32_FIXTURE,
+        space: 'tribute',
+      })
+    ).toBe(undefined);
+  });
+
+  test('should not throw when error; returns `undefined`', async () => {
+    server.use(
+      rest.get('http://*/api/*/draft/*', (_req, res, ctx) =>
+        res(ctx.status(500))
+      )
+    );
+
+    const getProposalErrorHandler = await import(
+      './helpers/getProposalErrorHandler'
+    );
+
+    const errorHandlerSpy = jest
+      .spyOn(getProposalErrorHandler, 'getProposalErrorHandler')
+      // Noop to avoid noisy error logging
+      .mockImplementation(() => {});
+
+    expect(
+      await legacyTributeDraftResolver({
+        // @see `docker-host` in `docker-compose.dev.yml`
+        apiBaseURL: 'http://docker-host:8081/api',
+        proposalID: BYTES32_FIXTURE,
+        space: 'tribute',
+      })
+    ).toBe(undefined);
+
+    expect(errorHandlerSpy.mock.calls.length).toBe(1);
+  });
+});

--- a/src/services/snapshotHub/legacyTributeProposalResolver.ts
+++ b/src/services/snapshotHub/legacyTributeProposalResolver.ts
@@ -8,7 +8,7 @@ import {fetchGetJSON} from '../../helpers';
 import {getProposalErrorHandler} from './helpers';
 
 /**
- * Resolves a legacy Snapshot proposal from a custom Tribute implementation.
+ * Resolves a legacy Snapshot proposal from a custom Tribute ERC-712 implementation.
  *
  * @param data `LegacyTributeProposalResolverData`
  * @returns `Promise<SnapshotHubProposalBase | undefined>`

--- a/src/services/snapshotHub/snapshotHubResolverSelector.ts
+++ b/src/services/snapshotHub/snapshotHubResolverSelector.ts
@@ -1,0 +1,21 @@
+import {
+  legacyTributeDraftResolver,
+  legacyTributeProposalResolver,
+  SnapshotHubProposalBase,
+  SnapshotHubProposalResolverArgs,
+} from '.';
+
+export async function snapshotHubResolverSelector<R = any>(
+  args: SnapshotHubProposalResolverArgs
+): Promise<SnapshotHubProposalBase<R> | undefined> {
+  switch (args.resolver) {
+    case 'LEGACY_TRIBUTE':
+      return await legacyTributeProposalResolver<R>(args);
+
+    case 'LEGACY_TRIBUTE_DRAFT':
+      return await legacyTributeDraftResolver<R>(args);
+
+    default:
+      return await legacyTributeProposalResolver<R>(args);
+  }
+}

--- a/src/services/snapshotHub/snapshotHubResolverSelector.unit.test.ts
+++ b/src/services/snapshotHub/snapshotHubResolverSelector.unit.test.ts
@@ -1,0 +1,83 @@
+import {BYTES32_FIXTURE} from '../../../test/fixtures';
+import {snapshotHubResolverSelector} from './snapshotHubResolverSelector';
+
+describe('snapshotHubResolverSelector unit tests', () => {
+  test('should call `legacyTributeProposalResolver` resolver', async () => {
+    const legacyTributeProposalResolver = await import(
+      '../snapshotHub/legacyTributeProposalResolver'
+    );
+
+    const legacyTributeProposalResolverMock = jest
+      .spyOn(legacyTributeProposalResolver, 'legacyTributeProposalResolver')
+      .mockImplementation(async () => undefined);
+
+    snapshotHubResolverSelector({
+      proposalID: BYTES32_FIXTURE,
+      space: 'test',
+      resolver: 'LEGACY_TRIBUTE',
+    });
+
+    // Assert `legacyTributeProposalResolver` called
+    expect(legacyTributeProposalResolverMock.mock.calls.length).toBe(1);
+
+    expect(legacyTributeProposalResolverMock.mock.calls[0][0]).toEqual({
+      proposalID: BYTES32_FIXTURE,
+      resolver: 'LEGACY_TRIBUTE',
+      space: 'test',
+    });
+
+    legacyTributeProposalResolverMock.mockRestore();
+  });
+
+  test('should call `legacyTributeDraftResolver` resolver', async () => {
+    const legacyTributeDraftResolver = await import(
+      '../snapshotHub/legacyTributeDraftResolver'
+    );
+
+    const legacyTributeDraftResolverMock = jest
+      .spyOn(legacyTributeDraftResolver, 'legacyTributeDraftResolver')
+      .mockImplementation(async () => undefined);
+
+    snapshotHubResolverSelector({
+      proposalID: BYTES32_FIXTURE,
+      space: 'test',
+      resolver: 'LEGACY_TRIBUTE_DRAFT',
+    });
+
+    // Assert `legacyTributeProposalResolver` called
+    expect(legacyTributeDraftResolverMock.mock.calls.length).toBe(1);
+
+    expect(legacyTributeDraftResolverMock.mock.calls[0][0]).toEqual({
+      proposalID: BYTES32_FIXTURE,
+      resolver: 'LEGACY_TRIBUTE_DRAFT',
+      space: 'test',
+    });
+
+    legacyTributeDraftResolverMock.mockRestore();
+  });
+
+  test('should call default resolver', async () => {
+    const legacyTributeProposalResolver = await import(
+      '../snapshotHub/legacyTributeProposalResolver'
+    );
+
+    const legacyTributeProposalResolverMock = jest
+      .spyOn(legacyTributeProposalResolver, 'legacyTributeProposalResolver')
+      .mockImplementation(async () => undefined);
+
+    snapshotHubResolverSelector({
+      proposalID: BYTES32_FIXTURE,
+      space: 'test',
+    });
+
+    // Assert `legacyTributeProposalResolver` called
+    expect(legacyTributeProposalResolverMock.mock.calls.length).toBe(1);
+
+    expect(legacyTributeProposalResolverMock.mock.calls[0][0]).toEqual({
+      proposalID: BYTES32_FIXTURE,
+      space: 'test',
+    });
+
+    legacyTributeProposalResolverMock.mockRestore();
+  });
+});

--- a/src/services/snapshotHub/types.ts
+++ b/src/services/snapshotHub/types.ts
@@ -2,6 +2,11 @@ import {SNAPSHOT_HUB_RESOLVERS} from '../../config';
 
 export type SnapshotProposalID = string;
 
+export enum SnapshotHubMessageType {
+  DRAFT = 'draft',
+  PROPOSAL = 'proposal',
+}
+
 /**
  * A base type for any Snapshot Hub proposal data structure
  *
@@ -63,6 +68,11 @@ export type SnapshotHubLegacyTributeProposalEntry = Record<
   SnapshotHubLegacyTributeProposal
 >;
 
+export type SnapshotHubLegacyTributeDraftEntry = Record<
+  SnapshotProposalID,
+  SnapshotHubLegacyTributeDraft
+>;
+
 /**
  * A basic Snapshot Hub proposal type for legacy
  * versions of Snapshot Hub.
@@ -85,6 +95,25 @@ export interface SnapshotHubLegacyProposal {
        */
       start: number;
     };
+    type: SnapshotHubMessageType;
+  };
+}
+
+/**
+ * A basic Snapshot Hub draft type for legacy
+ * versions of Snapshot Hub.
+ */
+export interface SnapshotHubLegacyDraft {
+  msg: {
+    payload: {
+      body: string;
+      name: string;
+    };
+    /**
+     * Created timestamp in seconds
+     */
+    timestamp: string;
+    type: SnapshotHubMessageType;
   };
 }
 
@@ -105,5 +134,22 @@ export interface SnapshotHubLegacyTributeProposal
      * proposals the actual DAO proposal's ID is the Snapshot Hub `draft` ID.
      */
     erc712DraftHash: string;
+  };
+}
+
+export interface SnapshotHubLegacyTributeDraft extends SnapshotHubLegacyDraft {
+  /**
+   * Proposal's Tribute DAO Adapter ID
+   */
+  actionId: string;
+  /**
+   * Partial type of legacy Tribute Snapshot Hub response
+   * customised for erc712 signatures
+   */
+  data: {
+    /**
+     * Has the draft been sponsored (i.e. proposal created from a draft)?
+     */
+    sponsored: boolean;
   };
 }

--- a/src/webhook-tasks/actions/snapshotHub/index.ts
+++ b/src/webhook-tasks/actions/snapshotHub/index.ts
@@ -1,3 +1,3 @@
 export * from './helpers';
-export * from './legacyTributeGovernanceProposalCreatedWebhook';
+export * from './legacyTributeGovernanceProposalCreated';
 export * from './types';

--- a/src/webhook-tasks/actions/snapshotHub/index.ts
+++ b/src/webhook-tasks/actions/snapshotHub/index.ts
@@ -1,3 +1,4 @@
 export * from './helpers';
+export * from './legacyTributeDraftCreated';
 export * from './legacyTributeGovernanceProposalCreated';
 export * from './types';

--- a/src/webhook-tasks/actions/snapshotHub/legacyTributeDraftCreated.ts
+++ b/src/webhook-tasks/actions/snapshotHub/legacyTributeDraftCreated.ts
@@ -1,0 +1,157 @@
+import {
+  getDaoAction,
+  getDaoDataBySnapshotSpace,
+  isDaoActionActive,
+  isDebug,
+} from '../../../helpers';
+import {
+  compileSimpleTemplate,
+  SNAPSHOT_DRAFT_CREATED_EMBED_TEMPLATE,
+  SNAPSHOT_DRAFT_CREATED_TEMPLATE,
+  SnapshotDraftCreatedEmbedTemplateData,
+  SnapshotDraftCreatedTemplateData,
+} from '../../templates';
+import {
+  SnapshotHubLegacyTributeDraft,
+  SnapshotHubMessageType,
+} from '../../../services/snapshotHub';
+import {actionErrorHandler} from '../helpers/actionErrorHandler';
+import {DaoData} from '../../../config/types';
+import {DiscordMessageEmbeds} from '..';
+import {EventSnapshotProposalWebhook} from '../../events/snapshotHub';
+import {getDiscordWebhookClient} from '../../../services/discord';
+import {getProposalAdapterID} from '../../../services';
+import {SnapshotHubEventPayload} from './types';
+import {takeSnapshotProposalID} from './helpers';
+
+/**
+ * Posts to a Discord channel when a legacy Tribute
+ * draft is created on a Snapshot Hub.
+ *
+ * @param event `EventSnapshotProposalWebhook`
+ * @param daos `Record<string, DaoData> | undefined` Web3.js subscription log data
+ *
+ * @returns `(d: SnapshotHubEventPayload) => Promise<void>`
+ */
+export function legacyTributeDraftCreatedAction(
+  event: EventSnapshotProposalWebhook,
+  daos: Record<string, DaoData> | undefined
+): (s: SnapshotHubEventPayload) => Promise<void> {
+  return async (snapshotEvent) => {
+    try {
+      if (!snapshotEvent || snapshotEvent.event !== event.snapshotEventName) {
+        return;
+      }
+
+      const {space} = snapshotEvent;
+      const dao = getDaoDataBySnapshotSpace(space, daos);
+      const daoAction = getDaoAction('SNAPSHOT_PROPOSAL_CREATED_WEBHOOK', dao);
+
+      if (
+        !dao ||
+        !dao.snapshotHub ||
+        !daoAction?.webhookID ||
+        !isDaoActionActive(daoAction)
+      ) {
+        return;
+      }
+      const {
+        adapters,
+        baseURL,
+        friendlyName,
+        registryContractAddress,
+        snapshotHub: {
+          proposalResolver: snapshotProposalResolver,
+          space: snapshotSpace,
+        },
+      } = dao;
+
+      const draftID: string = takeSnapshotProposalID(snapshotEvent.id);
+
+      const draft =
+        await snapshotProposalResolver<SnapshotHubLegacyTributeDraft>({
+          proposalID: draftID,
+          resolver: 'LEGACY_TRIBUTE_DRAFT',
+          space: snapshotSpace,
+        });
+
+      // Exit if no draft
+      if (!draft) return;
+
+      const {raw: draftRaw} = draft;
+
+      // Exit if not draft
+      if (draftRaw.msg.type !== SnapshotHubMessageType.DRAFT) {
+        return;
+      }
+
+      const adapterID = await getProposalAdapterID({
+        adapterAddress: draftRaw.actionId,
+        daoAddress: registryContractAddress,
+      });
+
+      // Exit if no `adapterID`
+      if (!adapterID) {
+        return;
+      }
+
+      const draftURL: string = `${baseURL}/${
+        adapters?.[adapterID || '']?.baseURLPath
+      }/${draftID}`;
+
+      const createdDateUTCString = new Date(
+        (Number(draftRaw.msg.timestamp) || 0) * 1000
+      ).toUTCString();
+
+      const content: string =
+        compileSimpleTemplate<SnapshotDraftCreatedTemplateData>(
+          SNAPSHOT_DRAFT_CREATED_TEMPLATE,
+          {
+            createdDateUTCString,
+            draftURL,
+            title: draft.title,
+          }
+        );
+
+      // Falls back to empty embed if no proposal
+      const embedBody: DiscordMessageEmbeds = [
+        {
+          color: 'DEFAULT',
+          description:
+            compileSimpleTemplate<SnapshotDraftCreatedEmbedTemplateData>(
+              SNAPSHOT_DRAFT_CREATED_EMBED_TEMPLATE,
+              {body: draft?.body}
+            ),
+        },
+      ];
+
+      // Merge any embeds
+      const embeds: DiscordMessageEmbeds = [...embedBody];
+
+      const client = await getDiscordWebhookClient(daoAction.webhookID);
+
+      const response = await client.send({
+        content,
+        // @see https://discord.com/developers/docs/resources/channel#embed-object-embed-structure
+        embeds,
+        username: `${friendlyName}`,
+      });
+
+      if (isDebug()) {
+        console.debug(
+          `Sent Discord message after ${event.name} event for ${
+            dao.friendlyName
+          }. Response:\n${JSON.stringify(response, null, 2)}`
+        );
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        actionErrorHandler({
+          actionName: 'SNAPSHOT_PROPOSAL_CREATED_WEBHOOK',
+          error,
+          event,
+        });
+      }
+    }
+  };
+}

--- a/src/webhook-tasks/actions/snapshotHub/legacyTributeDraftCreated.unit.test.ts
+++ b/src/webhook-tasks/actions/snapshotHub/legacyTributeDraftCreated.unit.test.ts
@@ -1,0 +1,434 @@
+import {DiscordWebhook} from '@prisma/client';
+import {WebhookClient} from 'discord.js';
+
+import {
+  BYTES32_FIXTURE,
+  DISCORD_WEBHOOK_POST_FIXTURE,
+  FAKE_DAOS_FIXTURE,
+  LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE,
+} from '../../../../test';
+import {
+  compileSimpleTemplate,
+  SNAPSHOT_DRAFT_CREATED_EMBED_TEMPLATE,
+  SNAPSHOT_DRAFT_CREATED_TEMPLATE,
+  SnapshotDraftCreatedEmbedTemplateData,
+  SnapshotDraftCreatedTemplateData,
+} from '../../templates';
+import {ActionNames, DaoData} from '../../../config';
+import {BURN_ADDRESS} from '../../../helpers';
+import {EventBase} from '../../events';
+import {legacyTributeDraftCreatedAction} from './legacyTributeDraftCreated';
+import {mockWeb3Provider} from '../../../../test/setup';
+import {prismaMock} from '../../../../test/prismaMock';
+import {rest, server} from '../../../../test/msw/server';
+import {SNAPSHOT_PROPOSAL_CREATED_EVENT} from '../../events/snapshotHub';
+import {SnapshotHubEventPayload, SnapshotHubEvents} from './types';
+import {
+  SnapshotHubLegacyTributeDraftEntry,
+  SnapshotHubMessageType,
+} from '../../../services/snapshotHub';
+import {web3} from '../../../singletons';
+
+type MockHelperReturn = Promise<{
+  cleanup: () => void;
+
+  errorHandlerSpy: jest.SpyInstance<
+    void,
+    [
+      {
+        actionName: ActionNames;
+        event: EventBase;
+        error: Error;
+      }
+    ]
+  >;
+
+  sendSpy?: jest.Mock<any, any>;
+
+  webhookClientMock?: jest.SpyInstance<
+    Promise<WebhookClient>,
+    [webhookID: string]
+  >;
+}>;
+
+async function mockHelper(
+  spyOnWebhookClient: boolean = true
+): MockHelperReturn {
+  let webhookClientMock:
+    | jest.SpyInstance<Promise<WebhookClient>, [webhookID: string]>
+    | undefined;
+
+  let sendSpy: jest.Mock<any, any> | undefined;
+
+  const webhook: DiscordWebhook = {
+    id: 1,
+    createdAt: new Date(0),
+    webhookID: 'abc123',
+    webhookToken: 'def456',
+    name: 'A Test Webhook',
+  };
+
+  // Spy on logging for test
+
+  const actionErrorHandler = await import('../helpers/actionErrorHandler');
+
+  const errorHandlerSpy = jest
+    .spyOn(actionErrorHandler, 'actionErrorHandler')
+    // Noop function to remove implementation, i.e. noisy error logs
+    .mockImplementation(() => {});
+
+  // Mock result
+  prismaMock.discordWebhook.findUnique.mockResolvedValue(webhook);
+
+  if (spyOnWebhookClient) {
+    // Mock Discord.js `WebhookClient.send`
+    const getDiscordWebhookClient = await import(
+      '../../../services/discord/getDiscordWebhookClient'
+    );
+
+    sendSpy = jest.fn();
+
+    webhookClientMock = jest
+      .spyOn(getDiscordWebhookClient, 'getDiscordWebhookClient')
+      .mockImplementation(async () => ({send: sendSpy} as any));
+  }
+
+  // Mock respsonse for `inverseAdapters`
+  mockWeb3Provider.injectResult(
+    web3.eth.abi.encodeParameters(['bytes32', 'uint256'], [BYTES32_FIXTURE, 1])
+  );
+
+  return {
+    cleanup: () => {
+      sendSpy?.mockReset();
+      webhookClientMock?.mockRestore();
+      errorHandlerSpy.mockRestore();
+    },
+    errorHandlerSpy,
+    sendSpy,
+    webhookClientMock,
+  };
+}
+
+const EVENT_DATA: SnapshotHubEventPayload = {
+  event: SnapshotHubEvents.PROPOSAL_CREATED,
+  expire: new Date(0).getTime() / 1000,
+  /**
+   * Proposal's ID string
+   */
+  id: `proposal/${BYTES32_FIXTURE}`,
+  /**
+   * Name of Snapshot Hub space
+   *
+   * e.g. 'fashion'
+   */
+  space: 'tribute',
+};
+
+const FAKE_DAOS: Record<string, DaoData> = {
+  ...FAKE_DAOS_FIXTURE,
+  test: {
+    ...FAKE_DAOS_FIXTURE.test,
+    actions: [
+      ...FAKE_DAOS_FIXTURE.test.actions,
+      {name: 'SNAPSHOT_PROPOSAL_CREATED_WEBHOOK', webhookID: 'abc123'},
+    ],
+    events: [
+      ...FAKE_DAOS_FIXTURE.test.events,
+      {name: 'SNAPSHOT_PROPOSAL_CREATED'},
+    ],
+  },
+};
+
+describe('legacyTributeDraftCreatedAction unit tests', () => {
+  test('should send Discord webhook message', async () => {
+    const {cleanup, sendSpy} = await mockHelper();
+
+    await legacyTributeDraftCreatedAction(
+      SNAPSHOT_PROPOSAL_CREATED_EVENT,
+      FAKE_DAOS
+    )(EVENT_DATA);
+
+    // Assert OK and `WebhookClient.send` called
+    expect(sendSpy?.mock.calls.length).toBe(1);
+
+    expect(sendSpy?.mock.calls[0][0]?.content).toBe(
+      compileSimpleTemplate<SnapshotDraftCreatedTemplateData>(
+        SNAPSHOT_DRAFT_CREATED_TEMPLATE,
+        {
+          createdDateUTCString: new Date(0 * 1000).toUTCString(),
+          draftURL: `http://localhost:3000/membership/${BYTES32_FIXTURE}`,
+          title:
+            LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE[BYTES32_FIXTURE].msg
+              .payload.name,
+        }
+      )
+    );
+
+    expect(sendSpy?.mock.calls[0][0]?.embeds).toEqual([
+      {
+        color: 'DEFAULT',
+        description:
+          compileSimpleTemplate<SnapshotDraftCreatedEmbedTemplateData>(
+            SNAPSHOT_DRAFT_CREATED_EMBED_TEMPLATE,
+            {
+              body: LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE[BYTES32_FIXTURE]
+                .msg.payload.body,
+            }
+          ),
+      },
+    ]);
+
+    expect(sendSpy?.mock.calls[0][0]?.username).toEqual(
+      FAKE_DAOS.test.friendlyName
+    );
+
+    cleanup();
+  });
+
+  test('should send Discord webhook message and log with `DEBUG=true`', async () => {
+    const consoleDebugOriginal = console.debug;
+    const consoleDebugSpy = (console.debug = jest.fn());
+
+    // Don't mock the client so we can inspect the response
+    const {cleanup} = await mockHelper(false);
+
+    const isDebugSpy = jest
+      .spyOn(await import('../../../helpers/isDebug'), 'isDebug')
+      .mockImplementation(() => true);
+
+    await legacyTributeDraftCreatedAction(
+      SNAPSHOT_PROPOSAL_CREATED_EVENT,
+      FAKE_DAOS
+    )(EVENT_DATA);
+
+    expect(consoleDebugSpy.mock.calls.length).toBe(1);
+
+    expect(consoleDebugSpy.mock.calls[0][0]).toMatch(
+      /sent discord message after snapshot_proposal_created event for tribute dao \[test\]/i
+    );
+
+    expect(consoleDebugSpy.mock.calls[0][0]).toContain(
+      JSON.stringify(DISCORD_WEBHOOK_POST_FIXTURE, null, 2)
+    );
+
+    // Cleanup
+
+    cleanup();
+
+    consoleDebugSpy.mockReset();
+    console.debug = consoleDebugOriginal;
+    isDebugSpy.mockRestore();
+  });
+
+  test('should not throw on Discord POST error', async () => {
+    // Mock response error
+    server.use(
+      rest.post('https://discord.com/api/*/webhooks/*/*', (_req, res, ctx) =>
+        res(ctx.status(500))
+      )
+    );
+
+    const {cleanup, errorHandlerSpy, sendSpy} = await mockHelper(false);
+
+    let assertError;
+
+    try {
+      await legacyTributeDraftCreatedAction(
+        SNAPSHOT_PROPOSAL_CREATED_EVENT,
+        FAKE_DAOS
+      )(EVENT_DATA);
+    } catch (error) {
+      assertError = error;
+    }
+
+    // Assert OK
+    expect(sendSpy?.mock.calls).toBe(undefined);
+    // Assert error logging was called
+    expect(errorHandlerSpy.mock.calls.length).toBe(1);
+    // Assert error was not thrown
+    expect(assertError).not.toBeDefined();
+
+    // Cleanup
+
+    cleanup();
+  });
+
+  test('should exit if no `snapshotEvent`', async () => {
+    const getDaoAction = await import('../../../helpers/getDaoAction');
+    const {cleanup, sendSpy} = await mockHelper();
+
+    const getDaoDataByAddressSpy = jest.spyOn(getDaoAction, 'getDaoAction');
+
+    await legacyTributeDraftCreatedAction(
+      SNAPSHOT_PROPOSAL_CREATED_EVENT,
+      FAKE_DAOS
+    )(undefined as any);
+
+    // Assert no `WebhookClient.send` called
+    expect(sendSpy?.mock.calls.length).toBe(0);
+    // Assert exit early
+    expect(getDaoDataByAddressSpy?.mock.calls.length).toBe(0);
+
+    cleanup();
+    getDaoDataByAddressSpy.mockRestore();
+  });
+
+  test('should exit if no draft found', async () => {
+    // Mock empty response
+    server.use(
+      rest.get('http://*/api/*/draft/*', (_req, res, ctx) => res(ctx.json({})))
+    );
+
+    const {cleanup, sendSpy} = await mockHelper();
+
+    let assertError;
+
+    try {
+      await legacyTributeDraftCreatedAction(
+        SNAPSHOT_PROPOSAL_CREATED_EVENT,
+        FAKE_DAOS
+      )(EVENT_DATA);
+    } catch (error) {
+      assertError = error;
+    }
+
+    // Assert no `WebhookClient.send` called
+    expect(sendSpy?.mock.calls.length).toBe(0);
+    // Assert error was not thrown
+    expect(assertError).not.toBeDefined();
+
+    // Cleanup
+
+    cleanup();
+  });
+
+  test('should exit if no `adapterID` found', async () => {
+    server.use(
+      rest.get<undefined, SnapshotHubLegacyTributeDraftEntry>(
+        'http://*/api/*/draft/*',
+        (_req, res, ctx) =>
+          res(
+            ctx.json({
+              ...LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE,
+              [BYTES32_FIXTURE]: {
+                ...LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE[BYTES32_FIXTURE],
+                // Use an empty `actionId` in order to trigger exit
+                actionId: '',
+              },
+            })
+          )
+      )
+    );
+
+    const {cleanup, sendSpy} = await mockHelper();
+
+    let assertError;
+
+    try {
+      await legacyTributeDraftCreatedAction(
+        SNAPSHOT_PROPOSAL_CREATED_EVENT,
+        FAKE_DAOS
+      )(EVENT_DATA);
+    } catch (error) {
+      assertError = error;
+    }
+
+    // Assert no `WebhookClient.send` called
+    expect(sendSpy?.mock.calls.length).toBe(0);
+    // Assert error was not thrown
+    expect(assertError).not.toBeDefined();
+
+    // Cleanup
+
+    cleanup();
+  });
+
+  test('should exit if response type is not `SnapshotHubMessageType.DRAFT`', async () => {
+    // Mock empty response
+    server.use(
+      rest.get('http://*/api/*/draft/*', (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE,
+            [BYTES32_FIXTURE]: {
+              ...LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE[BYTES32_FIXTURE],
+              actionId: BURN_ADDRESS,
+              msg: {
+                ...LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE[BYTES32_FIXTURE]
+                  .msg,
+                // Wrong type
+                type: SnapshotHubMessageType.PROPOSAL,
+              },
+            },
+          })
+        )
+      )
+    );
+
+    const {cleanup, sendSpy} = await mockHelper();
+
+    let assertError;
+
+    try {
+      await legacyTributeDraftCreatedAction(
+        SNAPSHOT_PROPOSAL_CREATED_EVENT,
+        FAKE_DAOS
+      )(EVENT_DATA);
+    } catch (error) {
+      assertError = error;
+    }
+
+    // Assert no `WebhookClient.send` called
+    expect(sendSpy?.mock.calls.length).toBe(0);
+    // Assert error was not thrown
+    expect(assertError).not.toBeDefined();
+
+    // Cleanup
+
+    cleanup();
+  });
+
+  test('should exit if `snapshotEvent.event !== event.snapshotEventName`', async () => {
+    const getDaoAction = await import('../../../helpers/getDaoAction');
+    const {cleanup, sendSpy} = await mockHelper();
+
+    const getDaoDataByAddressSpy = jest.spyOn(getDaoAction, 'getDaoAction');
+
+    await legacyTributeDraftCreatedAction(
+      SNAPSHOT_PROPOSAL_CREATED_EVENT,
+      FAKE_DAOS
+    )({...EVENT_DATA, event: SnapshotHubEvents.PROPOSAL_END});
+
+    // Assert no `WebhookClient.send` called
+    expect(sendSpy?.mock.calls.length).toBe(0);
+    // Assert exit early
+    expect(getDaoDataByAddressSpy?.mock.calls.length).toBe(0);
+
+    cleanup();
+    getDaoDataByAddressSpy.mockRestore();
+  });
+
+  test('should exit if action is not active', async () => {
+    const getProposalAdapterID = await import(
+      '../../../services/dao/getProposalAdapterID'
+    );
+
+    const getProposalAdapterIDMock = jest
+      .spyOn(getProposalAdapterID, 'getProposalAdapterID')
+      .mockImplementation(async () => undefined);
+
+    const {cleanup, sendSpy} = await mockHelper();
+
+    await legacyTributeDraftCreatedAction(
+      SNAPSHOT_PROPOSAL_CREATED_EVENT,
+      FAKE_DAOS
+    )(EVENT_DATA);
+
+    // Assert OK and `WebhookClient.send` called
+    expect(sendSpy?.mock.calls.length).toBe(0);
+
+    cleanup();
+    getProposalAdapterIDMock.mockRestore();
+  });
+});

--- a/src/webhook-tasks/actions/snapshotHub/legacyTributeGovernanceProposalCreated.ts
+++ b/src/webhook-tasks/actions/snapshotHub/legacyTributeGovernanceProposalCreated.ts
@@ -1,6 +1,5 @@
 import {
   BURN_ADDRESS,
-  DISCORD_EMPTY_EMBED,
   getDaoAction,
   getDaoDataBySnapshotSpace,
   isDaoActionActive,
@@ -11,18 +10,19 @@ import {
   compileSimpleTemplate,
   SNAPSHOT_GOVERNANCE_PROPOSAL_CREATED_TEMPLATE,
   SNAPSHOT_PROPOSAL_CREATED_EMBED_TEMPLATE,
-  SNAPSHOT_PROPOSAL_CREATED_FALLBACK_TEMPLATE,
   SnapshotProposalCreatedEmbedTemplateData,
-  SnapshotProposalCreatedFallbackTemplateData,
   SnapshotProposalCreatedTemplateData,
 } from '../../templates';
+import {
+  SnapshotHubLegacyTributeProposal,
+  SnapshotHubMessageType,
+} from '../../../services/snapshotHub';
 import {actionErrorHandler} from '../helpers/actionErrorHandler';
 import {DaoData} from '../../../config/types';
 import {DiscordMessageEmbeds} from '..';
 import {EventSnapshotProposalWebhook} from '../../events/snapshotHub';
 import {getDiscordWebhookClient} from '../../../services/discord';
 import {SnapshotHubEventPayload} from './types';
-import {SnapshotHubLegacyTributeProposal} from '../../../services/snapshotHub';
 import {takeSnapshotProposalID} from './helpers';
 
 /**
@@ -52,8 +52,7 @@ export function legacyTributeGovernanceProposalCreatedAction(
         !dao ||
         !dao.snapshotHub ||
         !daoAction?.webhookID ||
-        !isDaoActionActive(daoAction) ||
-        space !== dao.snapshotHub.space
+        !isDaoActionActive(daoAction)
       ) {
         return;
       }
@@ -78,52 +77,52 @@ export function legacyTributeGovernanceProposalCreatedAction(
           space: snapshotSpace,
         });
 
-      const proposalRaw = proposal?.raw;
+      // Exit if no proposal
+      if (!proposal) return;
+
+      const {raw: proposalRaw} = proposal;
+
+      // Exit if type is not `SnapshotHubMessageType.PROPOSAL`
+      if (proposalRaw.msg.type !== SnapshotHubMessageType.PROPOSAL) {
+        return;
+      }
 
       // Exit if fetched proposal is not governance
       if (
-        proposalRaw &&
-        normalizeString(proposalRaw?.actionId) !== normalizeString(BURN_ADDRESS)
+        normalizeString(proposalRaw.actionId) !== normalizeString(BURN_ADDRESS)
       ) {
         return;
       }
 
       const proposalURL: string = `${baseURL}/${
-        adapters?.[proposalRaw?.actionId || '']?.baseURLPath
+        adapters?.[proposalRaw.actionId]?.baseURLPath
       }/${proposalID}`;
 
       const voteEndsDateUTCString = new Date(
-        (proposalRaw?.msg?.payload?.end || 0) * 1000
+        (proposalRaw.msg.payload.end || 0) * 1000
       ).toUTCString();
 
-      const content: string = proposal
-        ? compileSimpleTemplate<SnapshotProposalCreatedTemplateData>(
-            SNAPSHOT_GOVERNANCE_PROPOSAL_CREATED_TEMPLATE,
-            {
-              title: proposal.title,
-              proposalURL,
-              voteEndsDateUTCString,
-            }
-          )
-        : compileSimpleTemplate<SnapshotProposalCreatedFallbackTemplateData>(
-            SNAPSHOT_PROPOSAL_CREATED_FALLBACK_TEMPLATE,
-            {baseURL, friendlyName}
-          );
+      const content: string =
+        compileSimpleTemplate<SnapshotProposalCreatedTemplateData>(
+          SNAPSHOT_GOVERNANCE_PROPOSAL_CREATED_TEMPLATE,
+          {
+            title: proposal.title,
+            proposalURL,
+            voteEndsDateUTCString,
+          }
+        );
 
       // Falls back to empty embed if no proposal
-      const embedBody: DiscordMessageEmbeds = proposal
-        ? [
-            {
-              color: 'DEFAULT',
-              description:
-                compileSimpleTemplate<SnapshotProposalCreatedEmbedTemplateData>(
-                  SNAPSHOT_PROPOSAL_CREATED_EMBED_TEMPLATE,
-                  {body: proposal?.body}
-                ),
-            },
-          ]
-        : DISCORD_EMPTY_EMBED;
-
+      const embedBody: DiscordMessageEmbeds = [
+        {
+          color: 'DEFAULT',
+          description:
+            compileSimpleTemplate<SnapshotProposalCreatedEmbedTemplateData>(
+              SNAPSHOT_PROPOSAL_CREATED_EMBED_TEMPLATE,
+              {body: proposal?.body}
+            ),
+        },
+      ];
       // Merge any embeds
       const embeds: DiscordMessageEmbeds = [...embedBody];
 

--- a/src/webhook-tasks/actions/snapshotHub/legacyTributeGovernanceProposalCreated.ts
+++ b/src/webhook-tasks/actions/snapshotHub/legacyTributeGovernanceProposalCreated.ts
@@ -29,12 +29,12 @@ import {takeSnapshotProposalID} from './helpers';
  * Posts to a Discord channel when a legacy Tribute
  * governance proposal is created on a Snapshot Hub.
  *
- * @param data `Log` Web3.js subscription log data
- * @returns `(d: Log) => Promise<void>`
+ * @param event `EventSnapshotProposalWebhook`
+ * @param daos `Record<string, DaoData> | undefined` Web3.js subscription log data
  *
- * @see https://web3js.readthedocs.io/en/v1.5.2/web3-eth-subscribe.html#subscribe-logs
+ * @returns `(d: SnapshotHubEventPayload) => Promise<void>`
  */
-export function legacyTributeGovernanceProposalCreatedWebhookAction(
+export function legacyTributeGovernanceProposalCreatedAction(
   event: EventSnapshotProposalWebhook,
   daos: Record<string, DaoData> | undefined
 ): (s: SnapshotHubEventPayload) => Promise<void> {

--- a/src/webhook-tasks/actions/snapshotHub/legacyTributeGovernanceProposalCreatedAction.unit.test.ts
+++ b/src/webhook-tasks/actions/snapshotHub/legacyTributeGovernanceProposalCreatedAction.unit.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../../test';
 import {ActionNames, DaoData} from '../../../config';
 import {EventBase} from '../../events';
-import {legacyTributeGovernanceProposalCreatedWebhookAction} from './legacyTributeGovernanceProposalCreatedWebhook';
+import {legacyTributeGovernanceProposalCreatedAction} from './legacyTributeGovernanceProposalCreated';
 import {mockWeb3Provider} from '../../../../test/setup';
 import {prismaMock} from '../../../../test/prismaMock';
 import {SNAPSHOT_PROPOSAL_CREATED_EVENT} from '../../events/snapshotHub';
@@ -172,13 +172,13 @@ const FAKE_DAOS_FIXTURE_GOVERNANCE: Record<string, DaoData> = {
   },
 };
 
-describe('legacyTributeGovernanceProposalCreatedWebhookAction unit tests', () => {
+describe('legacyTributeGovernanceProposalCreatedAction unit tests', () => {
   test('should send Discord webhook message', async () => {
     mockGovernanceProposalResponse();
 
     const {cleanup, sendSpy} = await mockHelper();
 
-    await legacyTributeGovernanceProposalCreatedWebhookAction(
+    await legacyTributeGovernanceProposalCreatedAction(
       SNAPSHOT_PROPOSAL_CREATED_EVENT,
       FAKE_DAOS_FIXTURE_GOVERNANCE
     )(EVENT_DATA);
@@ -234,7 +234,7 @@ describe('legacyTributeGovernanceProposalCreatedWebhookAction unit tests', () =>
 
     const {cleanup, sendSpy} = await mockHelper();
 
-    await legacyTributeGovernanceProposalCreatedWebhookAction(
+    await legacyTributeGovernanceProposalCreatedAction(
       SNAPSHOT_PROPOSAL_CREATED_EVENT,
       FAKE_DAOS_FIXTURE_GOVERNANCE
     )(EVENT_DATA);
@@ -273,7 +273,7 @@ describe('legacyTributeGovernanceProposalCreatedWebhookAction unit tests', () =>
       .spyOn(await import('../../../helpers/isDebug'), 'isDebug')
       .mockImplementation(() => true);
 
-    await legacyTributeGovernanceProposalCreatedWebhookAction(
+    await legacyTributeGovernanceProposalCreatedAction(
       SNAPSHOT_PROPOSAL_CREATED_EVENT,
       FAKE_DAOS_FIXTURE_GOVERNANCE
     )(EVENT_DATA);
@@ -312,7 +312,7 @@ describe('legacyTributeGovernanceProposalCreatedWebhookAction unit tests', () =>
     let assertError;
 
     try {
-      await legacyTributeGovernanceProposalCreatedWebhookAction(
+      await legacyTributeGovernanceProposalCreatedAction(
         SNAPSHOT_PROPOSAL_CREATED_EVENT,
         FAKE_DAOS_FIXTURE_GOVERNANCE
       )(EVENT_DATA);
@@ -338,7 +338,7 @@ describe('legacyTributeGovernanceProposalCreatedWebhookAction unit tests', () =>
 
     const getDaoDataByAddressSpy = jest.spyOn(getDaoAction, 'getDaoAction');
 
-    await legacyTributeGovernanceProposalCreatedWebhookAction(
+    await legacyTributeGovernanceProposalCreatedAction(
       SNAPSHOT_PROPOSAL_CREATED_EVENT,
       FAKE_DAOS_FIXTURE_GOVERNANCE
     )(undefined as any);
@@ -358,7 +358,7 @@ describe('legacyTributeGovernanceProposalCreatedWebhookAction unit tests', () =>
 
     const getDaoDataByAddressSpy = jest.spyOn(getDaoAction, 'getDaoAction');
 
-    await legacyTributeGovernanceProposalCreatedWebhookAction(
+    await legacyTributeGovernanceProposalCreatedAction(
       SNAPSHOT_PROPOSAL_CREATED_EVENT,
       FAKE_DAOS_FIXTURE_GOVERNANCE
     )({...EVENT_DATA, event: SnapshotHubEvents.PROPOSAL_END});
@@ -377,7 +377,7 @@ describe('legacyTributeGovernanceProposalCreatedWebhookAction unit tests', () =>
 
     const {cleanup, sendSpy} = await mockHelper();
 
-    await legacyTributeGovernanceProposalCreatedWebhookAction(
+    await legacyTributeGovernanceProposalCreatedAction(
       SNAPSHOT_PROPOSAL_CREATED_EVENT,
       FAKE_DAOS_FIXTURE_GOVERNANCE
     )(EVENT_DATA);
@@ -419,7 +419,7 @@ describe('legacyTributeGovernanceProposalCreatedWebhookAction unit tests', () =>
 
     const {cleanup, sendSpy} = await mockHelper();
 
-    await legacyTributeGovernanceProposalCreatedWebhookAction(
+    await legacyTributeGovernanceProposalCreatedAction(
       SNAPSHOT_PROPOSAL_CREATED_EVENT,
       FAKE_DAOS_NO_ACTION
     )(EVENT_DATA);

--- a/src/webhook-tasks/actions/snapshotHub/legacyTributeGovernanceProposalCreatedAction.unit.test.ts
+++ b/src/webhook-tasks/actions/snapshotHub/legacyTributeGovernanceProposalCreatedAction.unit.test.ts
@@ -10,25 +10,25 @@ import {
 } from '../../../../test';
 import {
   compileSimpleTemplate,
-  SnapshotProposalCreatedEmbedTemplateData,
-  SnapshotProposalCreatedTemplateData,
   SNAPSHOT_GOVERNANCE_PROPOSAL_CREATED_TEMPLATE,
   SNAPSHOT_PROPOSAL_CREATED_EMBED_TEMPLATE,
+  SnapshotProposalCreatedEmbedTemplateData,
+  SnapshotProposalCreatedTemplateData,
 } from '../../templates';
 import {
   SnapshotHubLegacyTributeProposalEntry,
   SnapshotHubMessageType,
 } from '../../../services/snapshotHub';
 import {ActionNames, DaoData} from '../../../config';
+import {BURN_ADDRESS} from '../../../helpers';
 import {EventBase} from '../../events';
 import {legacyTributeGovernanceProposalCreatedAction} from './legacyTributeGovernanceProposalCreated';
 import {mockWeb3Provider} from '../../../../test/setup';
 import {prismaMock} from '../../../../test/prismaMock';
+import {rest, server} from '../../../../test/msw/server';
 import {SNAPSHOT_PROPOSAL_CREATED_EVENT} from '../../events/snapshotHub';
 import {SnapshotHubEventPayload, SnapshotHubEvents} from './types';
 import {web3} from '../../../singletons';
-import {rest, server} from '../../../../test/msw/server';
-import {BURN_ADDRESS} from '../../../helpers';
 
 type MockHelperReturn = Promise<{
   cleanup: () => void;

--- a/src/webhook-tasks/actions/web3/subscribeLogs/sponsoredProposal.ts
+++ b/src/webhook-tasks/actions/web3/subscribeLogs/sponsoredProposal.ts
@@ -88,12 +88,20 @@ export function sponsoredProposalActionSubscribeLogs(
 
       const client = await getDiscordWebhookClient(daoAction.webhookID);
 
-      const adapterID = await getProposalAdapterID(
-        proposalId,
-        registryContractAddress
-      );
+      const adapterID = await getProposalAdapterID({
+        proposalID: proposalId,
+        daoAddress: registryContractAddress,
+      });
 
-      const proposalURL: string = `${baseURL}/${adapters?.[adapterID].baseURLPath}/${proposalId}`;
+      // Exit if no `adapterID`
+      if (!adapterID) {
+        return;
+      }
+
+      const proposalURL: string = `${baseURL}/${
+        adapters?.[adapterID || ''].baseURLPath
+      }/${proposalId}`;
+
       const txURL: string = `${getEtherscanURL()}/tx/${transactionHash}`;
 
       const proposal = await snapshotProposalResolver({

--- a/src/webhook-tasks/actions/web3/subscribeLogs/sponsoredProposal.unit.test.ts
+++ b/src/webhook-tasks/actions/web3/subscribeLogs/sponsoredProposal.unit.test.ts
@@ -248,4 +248,37 @@ describe('sponsoredProposal unit tests', () => {
     cleanup();
     getDaoDataByAddressSpy.mockRestore();
   });
+
+  test('should exit if no `adapterID` found', async () => {
+    const getProposalAdapterID = await import(
+      '../../../../services/dao/getProposalAdapterID'
+    );
+
+    const getProposalAdapterIDMock = jest
+      .spyOn(getProposalAdapterID, 'getProposalAdapterID')
+      .mockImplementation(async () => undefined);
+
+    const {cleanup, sendSpy} = await mockHelper();
+
+    let assertError;
+
+    try {
+      await sponsoredProposalActionSubscribeLogs(
+        SPONSORED_PROPOSAL_WEB3_LOGS,
+        FAKE_DAOS_FIXTURE
+      )(EVENT_DATA);
+    } catch (error) {
+      assertError = error;
+    }
+
+    // Assert no `WebhookClient.send` called
+    expect(sendSpy?.mock.calls.length).toBe(0);
+    // Assert error was not thrown
+    expect(assertError).not.toBeDefined();
+
+    // Cleanup
+
+    cleanup();
+    getProposalAdapterIDMock.mockRestore();
+  });
 });

--- a/src/webhook-tasks/runners/snapshotHub/proposalEventRunner.ts
+++ b/src/webhook-tasks/runners/snapshotHub/proposalEventRunner.ts
@@ -4,7 +4,7 @@ import {
 } from '../../actions/snapshotHub/types';
 import {Daos} from '../../../config';
 import {getDaos} from '../../../services';
-import {legacyTributeGovernanceProposalCreatedWebhookAction} from '../../actions/snapshotHub/legacyTributeGovernanceProposalCreatedWebhook';
+import {legacyTributeGovernanceProposalCreatedAction} from '../../actions/snapshotHub/legacyTributeGovernanceProposalCreated';
 import {runAll} from '../../../helpers';
 import {SNAPSHOT_PROPOSAL_CREATED_EVENT} from '../../events/snapshotHub';
 
@@ -46,7 +46,7 @@ function getProposalCreatedActions(
   daos: Daos | undefined
 ): SnapshotHubEventActions {
   return [
-    legacyTributeGovernanceProposalCreatedWebhookAction(
+    legacyTributeGovernanceProposalCreatedAction(
       SNAPSHOT_PROPOSAL_CREATED_EVENT,
       daos
     ),

--- a/src/webhook-tasks/runners/snapshotHub/proposalEventRunner.ts
+++ b/src/webhook-tasks/runners/snapshotHub/proposalEventRunner.ts
@@ -2,9 +2,12 @@ import {
   SnapshotHubEventPayload,
   SnapshotHubEvents,
 } from '../../actions/snapshotHub/types';
+import {
+  legacyTributeDraftCreatedAction,
+  legacyTributeGovernanceProposalCreatedAction,
+} from '../../actions/snapshotHub';
 import {Daos} from '../../../config';
 import {getDaos} from '../../../services';
-import {legacyTributeGovernanceProposalCreatedAction} from '../../actions/snapshotHub/legacyTributeGovernanceProposalCreated';
 import {runAll} from '../../../helpers';
 import {SNAPSHOT_PROPOSAL_CREATED_EVENT} from '../../events/snapshotHub';
 
@@ -46,6 +49,7 @@ function getProposalCreatedActions(
   daos: Daos | undefined
 ): SnapshotHubEventActions {
   return [
+    legacyTributeDraftCreatedAction(SNAPSHOT_PROPOSAL_CREATED_EVENT, daos),
     legacyTributeGovernanceProposalCreatedAction(
       SNAPSHOT_PROPOSAL_CREATED_EVENT,
       daos

--- a/src/webhook-tasks/runners/snapshotHub/proposalEventRunner.unit.test.ts
+++ b/src/webhook-tasks/runners/snapshotHub/proposalEventRunner.unit.test.ts
@@ -5,15 +5,23 @@ import {snapshotProposalEventRunner} from './proposalEventRunner';
 
 describe('proposalEventRunner unit tests', () => {
   test('should call actions for `SnapshotHubEvents.PROPOSAL_CREATED`', async () => {
-    const legacyTributeGovernanceProposalCreatedWebhook = await import(
+    const legacyTributeGovernanceProposalCreated = await import(
       '../../actions/snapshotHub/legacyTributeGovernanceProposalCreated'
     );
 
-    const actionSpy = jest
+    const legacyTributeDraftCreated = await import(
+      '../../actions/snapshotHub/legacyTributeDraftCreated'
+    );
+
+    const legacyTributeGovernanceProposalCreatedSpy = jest
       .spyOn(
-        legacyTributeGovernanceProposalCreatedWebhook,
+        legacyTributeGovernanceProposalCreated,
         'legacyTributeGovernanceProposalCreatedAction'
       )
+      .mockImplementation(() => async () => undefined);
+
+    const legacyTributeDraftCreatedSpy = jest
+      .spyOn(legacyTributeDraftCreated, 'legacyTributeDraftCreatedAction')
       .mockImplementation(() => async () => undefined);
 
     await snapshotProposalEventRunner({
@@ -23,25 +31,52 @@ describe('proposalEventRunner unit tests', () => {
       space: 'test',
     });
 
-    expect(actionSpy.mock.calls.length).toBe(1);
-    expect(actionSpy.mock.calls[0][0]).toEqual(SNAPSHOT_PROPOSAL_CREATED_EVENT);
-    expect(actionSpy.mock.calls[0][1]).toEqual(await getDaos());
+    // Assert `legacyTributeGovernanceProposalCreated` called
+    expect(legacyTributeGovernanceProposalCreatedSpy.mock.calls.length).toBe(1);
+
+    expect(legacyTributeGovernanceProposalCreatedSpy.mock.calls[0][0]).toEqual(
+      SNAPSHOT_PROPOSAL_CREATED_EVENT
+    );
+
+    expect(legacyTributeGovernanceProposalCreatedSpy.mock.calls[0][1]).toEqual(
+      await getDaos()
+    );
+
+    // Assert `legacyTributeDraftCreated` called
+    expect(legacyTributeDraftCreatedSpy.mock.calls.length).toBe(1);
+
+    expect(legacyTributeDraftCreatedSpy.mock.calls[0][0]).toEqual(
+      SNAPSHOT_PROPOSAL_CREATED_EVENT
+    );
+
+    expect(legacyTributeDraftCreatedSpy.mock.calls[0][1]).toEqual(
+      await getDaos()
+    );
 
     // Cleanup
 
-    actionSpy.mockRestore();
+    legacyTributeGovernanceProposalCreatedSpy.mockRestore();
+    legacyTributeDraftCreatedSpy.mockRestore();
   });
 
   test('should not call actions if none found', async () => {
-    const legacyTributeGovernanceProposalCreatedWebhook = await import(
+    const legacyTributeGovernanceProposalCreated = await import(
       '../../actions/snapshotHub/legacyTributeGovernanceProposalCreated'
     );
 
-    const actionSpy = jest
+    const legacyTributeDraftCreated = await import(
+      '../../actions/snapshotHub/legacyTributeDraftCreated'
+    );
+
+    const legacyTributeGovernanceProposalCreatedSpy = jest
       .spyOn(
-        legacyTributeGovernanceProposalCreatedWebhook,
+        legacyTributeGovernanceProposalCreated,
         'legacyTributeGovernanceProposalCreatedAction'
       )
+      .mockImplementation(() => async () => undefined);
+
+    const legacyTributeDraftCreatedSpy = jest
+      .spyOn(legacyTributeDraftCreated, 'legacyTributeDraftCreatedAction')
       .mockImplementation(() => async () => undefined);
 
     await snapshotProposalEventRunner({
@@ -51,10 +86,12 @@ describe('proposalEventRunner unit tests', () => {
       space: 'test',
     });
 
-    expect(actionSpy.mock.calls.length).toBe(0);
+    expect(legacyTributeGovernanceProposalCreatedSpy.mock.calls.length).toBe(0);
+    expect(legacyTributeDraftCreatedSpy.mock.calls.length).toBe(0);
 
     // Cleanup
 
-    actionSpy.mockRestore();
+    legacyTributeGovernanceProposalCreatedSpy.mockRestore();
+    legacyTributeDraftCreatedSpy.mockRestore();
   });
 });

--- a/src/webhook-tasks/runners/snapshotHub/proposalEventRunner.unit.test.ts
+++ b/src/webhook-tasks/runners/snapshotHub/proposalEventRunner.unit.test.ts
@@ -1,22 +1,18 @@
-import {FAKE_DAOS_FIXTURE} from '../../../../test/fixtures/fakeDaos';
 import {getDaos} from '../../../services';
-import {
-  SnapshotHubEventPayload,
-  SnapshotHubEvents,
-} from '../../actions/snapshotHub/types';
 import {SNAPSHOT_PROPOSAL_CREATED_EVENT} from '../../events/snapshotHub';
+import {SnapshotHubEvents} from '../../actions/snapshotHub/types';
 import {snapshotProposalEventRunner} from './proposalEventRunner';
 
 describe('proposalEventRunner unit tests', () => {
   test('should call actions for `SnapshotHubEvents.PROPOSAL_CREATED`', async () => {
     const legacyTributeGovernanceProposalCreatedWebhook = await import(
-      '../../actions/snapshotHub/legacyTributeGovernanceProposalCreatedWebhook'
+      '../../actions/snapshotHub/legacyTributeGovernanceProposalCreated'
     );
 
     const actionSpy = jest
       .spyOn(
         legacyTributeGovernanceProposalCreatedWebhook,
-        'legacyTributeGovernanceProposalCreatedWebhookAction'
+        'legacyTributeGovernanceProposalCreatedAction'
       )
       .mockImplementation(() => async () => undefined);
 
@@ -38,13 +34,13 @@ describe('proposalEventRunner unit tests', () => {
 
   test('should not call actions if none found', async () => {
     const legacyTributeGovernanceProposalCreatedWebhook = await import(
-      '../../actions/snapshotHub/legacyTributeGovernanceProposalCreatedWebhook'
+      '../../actions/snapshotHub/legacyTributeGovernanceProposalCreated'
     );
 
     const actionSpy = jest
       .spyOn(
         legacyTributeGovernanceProposalCreatedWebhook,
-        'legacyTributeGovernanceProposalCreatedWebhookAction'
+        'legacyTributeGovernanceProposalCreatedAction'
       )
       .mockImplementation(() => async () => undefined);
 

--- a/src/webhook-tasks/templates/snapshotHub/draftCreated.ts
+++ b/src/webhook-tasks/templates/snapshotHub/draftCreated.ts
@@ -1,0 +1,25 @@
+// Types
+
+export type SnapshotDraftCreatedTemplateData = {
+  draftURL?: string;
+  title?: string;
+  createdDateUTCString?: string;
+};
+
+export type SnapshotDraftCreatedEmbedTemplateData = {
+  body?: string;
+};
+
+// Templates
+
+/**
+ * Main content for a created draft
+ */
+export const SNAPSHOT_DRAFT_CREATED_TEMPLATE: string = `
+ A new proposal, [*{{title}}*]({{draftURL}}), has been submitted on {{createdDateUTCString}}.`;
+
+/**
+ * Template for an embed of the body of the Snapshot Hub draft
+ */
+export const SNAPSHOT_DRAFT_CREATED_EMBED_TEMPLATE: string = `
+{{body}}`;

--- a/src/webhook-tasks/templates/snapshotHub/index.ts
+++ b/src/webhook-tasks/templates/snapshotHub/index.ts
@@ -1,1 +1,2 @@
+export * from './draftCreated';
 export * from './proposalCreated';

--- a/src/webhook-tasks/templates/snapshotHub/proposalCreated.ts
+++ b/src/webhook-tasks/templates/snapshotHub/proposalCreated.ts
@@ -6,11 +6,6 @@ export type SnapshotProposalCreatedTemplateData = {
   voteEndsDateUTCString?: string;
 };
 
-export type SnapshotProposalCreatedFallbackTemplateData = {
-  baseURL?: string;
-  friendlyName?: string;
-};
-
 export type SnapshotProposalCreatedEmbedTemplateData = {
   body?: string;
 };
@@ -29,17 +24,6 @@ export const SNAPSHOT_PROPOSAL_CREATED_TEMPLATE: string = `
 export const SNAPSHOT_GOVERNANCE_PROPOSAL_CREATED_TEMPLATE: string = `
 Governance ⚖️
 ${SNAPSHOT_PROPOSAL_CREATED_TEMPLATE}`;
-
-/**
- * Fallback template in case the Snapshot Hub proposal
- * cannot be fetched for some reason.
- */
-export const SNAPSHOT_PROPOSAL_CREATED_FALLBACK_TEMPLATE: string = `
-A proposal is up for vote (proposal data could not be fetched).
-
-Find it at [{{friendlyName}}]({{baseURL}}).
-
-`;
 
 /**
  * Template for an embed of the body of the Snapshot Hub proposal

--- a/test/fixtures/fakeDaos.ts
+++ b/test/fixtures/fakeDaos.ts
@@ -1,6 +1,10 @@
+import {
+  legacyTributeDraftResolver,
+  legacyTributeProposalResolver,
+  SnapshotHubProposalResolverArgs,
+} from '../../src/services/snapshotHub';
 import {DaoData} from '../../src/config/types';
 import {BYTES32_FIXTURE, ETH_ADDRESS_FIXTURE} from './constants';
-import {legacyTributeProposalResolver} from '../../src/services/snapshotHub';
 
 export const FAKE_DAOS_FIXTURE: Record<string, DaoData> = {
   test: {
@@ -21,12 +25,27 @@ export const FAKE_DAOS_FIXTURE: Record<string, DaoData> = {
     friendlyName: 'Tribute DAO [Test]',
     registryContractAddress: ETH_ADDRESS_FIXTURE,
     snapshotHub: {
-      proposalResolver: async (args) =>
-        await legacyTributeProposalResolver({
+      proposalResolver: async <R = any>(
+        args: SnapshotHubProposalResolverArgs
+      ) => {
+        const {resolver} = args;
+
+        const DEFAULT_ARGS = {
           ...args,
-          // @see `docker-host` in `docker-compose.dev.yml`
           apiBaseURL: 'http://docker-host:8081/api',
-        }),
+        };
+
+        switch (resolver) {
+          case 'LEGACY_TRIBUTE':
+            return await legacyTributeProposalResolver<R>(DEFAULT_ARGS);
+
+          case 'LEGACY_TRIBUTE_DRAFT':
+            return await legacyTributeDraftResolver<R>(DEFAULT_ARGS);
+
+          default:
+            return await legacyTributeProposalResolver<R>(DEFAULT_ARGS);
+        }
+      },
       space: 'tribute',
     },
   },
@@ -49,12 +68,27 @@ export const FAKE_DAOS_FIXTURE: Record<string, DaoData> = {
     friendlyName: 'Mingo DAO [Test]',
     registryContractAddress: ETH_ADDRESS_FIXTURE,
     snapshotHub: {
-      proposalResolver: async (args) =>
-        await legacyTributeProposalResolver({
+      proposalResolver: async <R = any>(
+        args: SnapshotHubProposalResolverArgs
+      ) => {
+        const {resolver} = args;
+
+        const DEFAULT_ARGS = {
           ...args,
-          // @see `docker-host` in `docker-compose.dev.yml`
           apiBaseURL: 'http://docker-host:8081/api',
-        }),
+        };
+
+        switch (resolver) {
+          case 'LEGACY_TRIBUTE':
+            return await legacyTributeProposalResolver<R>(DEFAULT_ARGS);
+
+          case 'LEGACY_TRIBUTE_DRAFT':
+            return await legacyTributeDraftResolver<R>(DEFAULT_ARGS);
+
+          default:
+            return await legacyTributeProposalResolver<R>(DEFAULT_ARGS);
+        }
+      },
       space: 'mingo',
     },
   },

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -1,4 +1,5 @@
 export * from './constants';
 export * from './discordWebhookPOST';
 export * from './fakeDaos';
+export * from './legacySnapshotHubDraft';
 export * from './legacySnapshotHubProposal';

--- a/test/fixtures/legacySnapshotHubDraft.ts
+++ b/test/fixtures/legacySnapshotHubDraft.ts
@@ -1,24 +1,22 @@
 import {
-  SnapshotHubLegacyTributeProposalEntry,
+  SnapshotHubLegacyTributeDraftEntry,
   SnapshotHubMessageType,
 } from '../../src/services/snapshotHub';
 import {BYTES32_FIXTURE} from './constants';
 import {ETH_ADDRESS_FIXTURE} from '.';
 
-export const LEGACY_TRIBUTE_SNAPSHOT_HUB_PROPOSAL_FIXTURE: SnapshotHubLegacyTributeProposalEntry =
+export const LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE: SnapshotHubLegacyTributeDraftEntry =
   {
     [BYTES32_FIXTURE]: {
       actionId: ETH_ADDRESS_FIXTURE,
-      data: {erc712DraftHash: BYTES32_FIXTURE},
+      data: {sponsored: false},
       msg: {
         payload: {
           body: 'Wow, what a cool submission!',
-          end: 1637071441,
           name: 'Test Proposal',
-          snapshot: 123,
-          start: 1637071321,
         },
-        type: SnapshotHubMessageType.PROPOSAL,
+        timestamp: (new Date(0).getTime() / 1000).toFixed(),
+        type: SnapshotHubMessageType.DRAFT,
       },
     },
   };

--- a/test/msw/serverHandlersREST.ts
+++ b/test/msw/serverHandlersREST.ts
@@ -2,10 +2,14 @@ import {APIMessage} from 'discord-api-types';
 
 import {
   DISCORD_WEBHOOK_POST_FIXTURE,
+  LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE,
   LEGACY_TRIBUTE_SNAPSHOT_HUB_PROPOSAL_FIXTURE,
 } from '..';
+import {
+  SnapshotHubLegacyTributeDraftEntry,
+  SnapshotHubLegacyTributeProposalEntry,
+} from '../../src/services/snapshotHub';
 import {rest} from './server';
-import {SnapshotHubLegacyTributeProposalEntry} from '../../src/services/snapshotHub';
 
 /**
  * HTTP API
@@ -47,6 +51,13 @@ const snapshotHubLegacyTributeProposalGET = rest.get<
   res(ctx.json(LEGACY_TRIBUTE_SNAPSHOT_HUB_PROPOSAL_FIXTURE))
 );
 
+const snapshotHubLegacyTributeDraftGET = rest.get<
+  undefined,
+  SnapshotHubLegacyTributeDraftEntry
+>('http://*/api/*/draft/*', (_req, res, ctx) =>
+  res(ctx.json(LEGACY_TRIBUTE_SNAPSHOT_HUB_DRAFT_FIXTURE))
+);
+
 /**
  * HANDLERS TO EXPORT
  */
@@ -55,5 +66,6 @@ export const handlers = [
   alchemyAPI,
   discordWebhookPOST,
   httpAPIAllGET,
+  snapshotHubLegacyTributeDraftGET,
   snapshotHubLegacyTributeProposalGET,
 ];


### PR DESCRIPTION
Fixes #48 

When a snapshot hub draft is created Discord channels can now be notified.

🥳 **Adds**

- `legacyTributeDraftResolver` in order to properly get Snapshot Hub drafts
- `legacyTributeDraftCreated` snapshot hub action
- `draftCreated` template

✨ **Updates**

- Adds Muse0 to list of development DAOs
- Simplifies Snapshot Hub resolver selection via `snapshotHubResolverSelector`
- Adds `LEGACY_TRIBUTE_DRAFT` to list of snapshot hub resolvers
- Improves `getProposalAdapterID` to accept `adapterAddress` and skip a call to the chain
- Removes fallback template from snapshot governance action as it was running when it was not supposed to and provided little value.
- Updates exit conditions in snapshot governance action
- Updates exit conditions in sponsored proposal action
- Adds new snapshot draft action to `proposalEventRunner`
