### PR TITLE
Adds `codecov` config and ignore path for `test`

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  # ignore `test` dir and all its contents
+  - "test"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,3 @@
 ignore:
   # ignore `test` dir and all its contents
-  - "./test"
+  - "test/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,3 @@
 ignore:
   # ignore `test` dir and all its contents
-  - "test"
+  - "./test"


### PR DESCRIPTION


🧹 **Chores done**

- Adds `test` dir to ignored Codecov paths
