### PR TITLE
Fixes `APP_ENV` import order bug

### DIFF
--- a/src/config/applications.ts
+++ b/src/config/applications.ts
@@ -1,8 +1,8 @@
+import {APP_ENV} from './common';
+
 /**
  * Register unique application names
  */
-
-import {APP_ENV} from '.';
 
 export const APPLICATIONS = ['FLOOR_SWEEPER_POLL_BOT'] as const;
 


### PR DESCRIPTION
🐞 **Bugs squashed**

- The `APP_ENV` helper var was not correct as it was using the `index.ts` and `applications` was exported *before* `common`


