### PR TITLE
fix prod SWEEP_EXTERNAL_URL

### DIFF
--- a/src/applications/floor-sweeper-poll/config.ts
+++ b/src/applications/floor-sweeper-poll/config.ts
@@ -27,5 +27,5 @@ export const POLL_REACTION_EMOJIS: Record<
 
 export const SWEEP_EXTERNAL_URL: string =
   APP_ENV === 'production'
-    ? 'https://tools.tributelabs.xyz/floor-sweeper/'
+    ? 'https://tools.tributelabs.xyz/floor-sweeper'
     : 'https://develop--tools-tributelabs.netlify.app/floor-sweeper';


### PR DESCRIPTION
✨ **Updates**

- remove trailing `/` from production `SWEEP_EXTERNAL_URL` (The trailing slash was appropriately resolved in the tools dapp and didn't actually break anything. This is just clean up to not have to rely on the dapp to handle.)
