### PR TITLE
Adds initial `flamingo` (moloch dao) prod config

### DIFF
--- a/src/config/daos/daosProduction.ts
+++ b/src/config/daos/daosProduction.ts
@@ -116,8 +116,7 @@ export const DAOS_PRODUCTION: Record<
     applications: {
       FLOOR_SWEEPER_POLL_BOT: {
         name: 'FLOOR_SWEEPER_POLL_BOT',
-        // @todo
-        resultChannelID: '',
+        resultChannelID: '938470347521540137',
       },
     },
     baseURL: 'https://flamingodao.xyz',

--- a/src/config/daos/daosProduction.ts
+++ b/src/config/daos/daosProduction.ts
@@ -12,10 +12,15 @@ import {DaoData} from '../types';
  * If you want a DAO to interact with a Discord server,
  * start by adding its information to the enum and
  * exported mapping below.
+ *
+ * @todo we need to handle Moloch-based DAOs as first-class citizens
+ *   - `snapshotHub.proposalResolver`
+ *   - `DAO address`
  */
 
 export const DAO_NAMES_PRODUCTION = [
   'fashion',
+  'flamingo',
   'metaverse',
   'muse0',
   'music',
@@ -101,6 +106,25 @@ export const DAOS_PRODUCTION: Record<
       proposalResolver: DEFAULT_PROPOSAL_RESOLVER,
       space: 'fashion',
     },
+  },
+
+  /**
+   * Moloch DAO
+   */
+  flamingo: {
+    actions: [],
+    applications: {
+      FLOOR_SWEEPER_POLL_BOT: {
+        name: 'FLOOR_SWEEPER_POLL_BOT',
+        // @todo
+        resultChannelID: '',
+      },
+    },
+    baseURL: 'https://flamingodao.xyz',
+    events: [],
+    friendlyName: 'Flamingo',
+    guildID: '757641966530855074',
+    registryContractAddress: '',
   },
 
   metaverse: {


### PR DESCRIPTION
- [x] Add `resultChannelID` when channel is created

---

✨ **Updates**

- Production DAOs config: adds `flamingo` (Moloch-based DAO) config for accessing the `FLOOR_SWEEPER_POLL_BOT`
