### PR TITLE
Updates `FLOOR_SWEEPER_POLL_BOT_ID` to match tribute labs team

### DIFF
--- a/src/config/applications.ts
+++ b/src/config/applications.ts
@@ -18,10 +18,10 @@ export const APPLICATIONS = ['FLOOR_SWEEPER_POLL_BOT'] as const;
 // Tribute Labs Discord Team Application IDs
 export const FLOOR_SWEEPER_POLL_BOT_ID: string =
   APP_ENV === 'production'
-    ? '938779189161644062'
+    ? '938837219282681936'
     : APP_ENV === 'development'
-    ? '938775957949530113'
-    : '938763190702063617'; /* localhost development */
+    ? '938835275696705556'
+    : '938831672063954964'; /* localhost development */
 
 /**
  * Development Guild ID for faster development


### PR DESCRIPTION

🧹 **Chores done**

- Updating application IDs after creating a new `Tribute Labs` Discord team under my original account and transferred ownership to Jarrel. My new "work" account was disabled by Discord, for some reason.
