### PR TITLE
uses `uuid_generate_v4()` function in `uuid` columns

### DIFF
--- a/prisma/migrations/20220217161920_/migration.sql
+++ b/prisma/migrations/20220217161920_/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - Made the column `uuid` on table `buy_nft_poll` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `uuid` on table `floor_sweeper_poll` required. This step will fail if there are existing NULL values in that column.
+
+*/
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- AlterTable
+ALTER TABLE "buy_nft_poll" ALTER COLUMN "uuid" SET NOT NULL,
+ALTER COLUMN "uuid" SET DEFAULT uuid_generate_v4();
+
+-- AlterTable
+ALTER TABLE "floor_sweeper_poll" ALTER COLUMN "uuid" SET NOT NULL,
+ALTER COLUMN "uuid" SET DEFAULT uuid_generate_v4();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,7 @@ model DiscordWebhook {
 
 model FloorSweeperPoll {
   id              Int      @id @default(autoincrement())
-  uuid            String?  @unique @default(uuid()) @db.Uuid
+  uuid            String   @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   createdAt       DateTime @default(now())
   question        String   @db.VarChar(255)
   contractAddress String   @db.VarChar(255)
@@ -44,7 +44,7 @@ model FloorSweeperPoll {
 
 model BuyNFTPoll {
   id              Int      @id @default(autoincrement())
-  uuid            String?  @unique @default(uuid()) @db.Uuid
+  uuid            String   @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   createdAt       DateTime @default(now())
   name            String   @db.VarChar(255)
   contractAddress String   @db.VarChar(255)


### PR DESCRIPTION

✨ **Updates**

**db migration:**
  - `buy_nft_poll`, `floor_sweeper_poll` uses `uuid_generate_v4()` to generate a default UUID.
  - `buy_nft_poll`, `floor_sweeper_poll` `uuid` column set to `NOT NULL`


