### PR TITLE
Add `/fund` command

### DIFF
--- a/prisma/migrations/20220221161349_/migration.sql
+++ b/prisma/migrations/20220221161349_/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "fund_address_poll" (
+    "id" SERIAL NOT NULL,
+    "uuid" UUID NOT NULL DEFAULT uuid_generate_v4(),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "purpose" VARCHAR(255) NOT NULL,
+    "addressToFund" VARCHAR(255) NOT NULL,
+    "amountUSDC" INTEGER NOT NULL DEFAULT 0,
+    "processed" BOOLEAN NOT NULL DEFAULT false,
+    "voteThreshold" INTEGER NOT NULL DEFAULT 0,
+    "upvoteCount" INTEGER NOT NULL DEFAULT 0,
+    "guildID" VARCHAR(255) NOT NULL,
+    "channelID" VARCHAR(255) NOT NULL,
+    "messageID" VARCHAR(255) NOT NULL,
+
+    CONSTRAINT "fund_address_poll_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "fund_address_poll_uuid_key" ON "fund_address_poll"("uuid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "fund_address_poll_messageID_key" ON "fund_address_poll"("messageID");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,3 +58,20 @@ model BuyNFTPoll {
 
   @@map("buy_nft_poll")
 }
+
+model FundAddressPoll {
+  id            Int      @id @default(autoincrement())
+  uuid          String   @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  createdAt     DateTime @default(now())
+  purpose       String   @db.VarChar(255)
+  addressToFund String   @db.VarChar(255)
+  amountUSDC    Int      @default(0) @db.Integer
+  processed     Boolean  @default(false) @db.Boolean
+  voteThreshold Int      @default(0) @db.Integer
+  upvoteCount   Int      @default(0) @db.Integer
+  guildID       String   @db.VarChar(255)
+  channelID     String   @db.VarChar(255)
+  messageID     String   @unique @db.VarChar(255)
+
+  @@map("fund_address_poll")
+}

--- a/src/applications/tribute-tools/commands/buy.ts
+++ b/src/applications/tribute-tools/commands/buy.ts
@@ -4,12 +4,12 @@ import {SlashCommandBuilder} from '@discordjs/builders';
 import {URL} from 'url';
 import fetch from 'node-fetch';
 
-import {BUY_ALLOWED_EMOJIS} from '../config';
 import {Command} from '../../types';
 import {getDaoDataByGuildID} from '../../../helpers';
 import {getDaos} from '../../../services';
 import {getVoteThreshold} from '../helpers';
 import {prisma} from '../../../singletons';
+import {THUMBS_EMOJIS} from '../config';
 
 const COMMAND_NAME: string = 'buy';
 
@@ -291,7 +291,7 @@ async function execute(interaction: CommandInteraction) {
     });
 
     // React with thumbs up, and thumbs down voting buttons as emojis
-    const reactionPromises = BUY_ALLOWED_EMOJIS.map(
+    const reactionPromises = THUMBS_EMOJIS.map(
       (emoji) => async () => await message.react(emoji)
     );
 

--- a/src/applications/tribute-tools/commands/fund.ts
+++ b/src/applications/tribute-tools/commands/fund.ts
@@ -6,12 +6,12 @@ import {
 } from 'discord.js';
 import {SlashCommandBuilder} from '@discordjs/builders';
 
-import {BUY_ALLOWED_EMOJIS} from '../config';
 import {Command} from '../../types';
 import {DEV_COMMAND_NOT_READY} from '../helpers';
 import {getDaoDataByGuildID, normalizeString} from '../../../helpers';
 import {getDaos} from '../../../services';
-import {web3} from '../../../singletons';
+import {prisma, web3} from '../../../singletons';
+import {THUMBS_EMOJIS} from '../config';
 
 const COMMAND_NAME: string = 'fund';
 
@@ -131,6 +131,7 @@ async function execute(interaction: CommandInteraction) {
     embeds: [embed],
     fetchReply: true,
   })) as Message;
+
   try {
     const {guildId: guildID, channelId: channelID, id: messageID} = message;
 
@@ -143,7 +144,7 @@ async function execute(interaction: CommandInteraction) {
     // @todo Store poll data in DB
 
     // React with thumbs up, and thumbs down voting buttons as emojis
-    const reactionPromises = BUY_ALLOWED_EMOJIS.map(
+    const reactionPromises = THUMBS_EMOJIS.map(
       (emoji) => async () => await message.react(emoji)
     );
 

--- a/src/applications/tribute-tools/commands/fund.ts
+++ b/src/applications/tribute-tools/commands/fund.ts
@@ -1,9 +1,4 @@
-import {
-  CommandInteraction,
-  Message,
-  MessageEmbed,
-  EmbedFooterData,
-} from 'discord.js';
+import {CommandInteraction, Message, MessageEmbed} from 'discord.js';
 import {SlashCommandBuilder} from '@discordjs/builders';
 
 import {Command} from '../../types';
@@ -141,7 +136,10 @@ async function execute(interaction: CommandInteraction) {
       );
     }
 
-    // @todo Store poll data in DB
+    // Store poll data in DB
+    await prisma.fundAddressPoll.create({
+      data: {addressToFund, amountUSDC, channelID, guildID, messageID, purpose},
+    });
 
     // React with thumbs up, and thumbs down voting buttons as emojis
     const reactionPromises = THUMBS_EMOJIS.map(

--- a/src/applications/tribute-tools/commands/fund.ts
+++ b/src/applications/tribute-tools/commands/fund.ts
@@ -122,9 +122,8 @@ async function execute(interaction: CommandInteraction) {
   const embed = new MessageEmbed()
     .setTitle(purpose)
     .setDescription(
-      `📊 **Should we fund \`${addressToFund}\` for ${new Intl.NumberFormat(
-        'en-US',
-        {style: 'currency', currency: 'USD'}
+      `📊 **Should we fund \`${addressToFund}\` for $${new Intl.NumberFormat(
+        'en-US'
       ).format(amountUSDC)} USDC?**\n\u200B`
     ) /* `\u200B` = zero-width space */
     .setURL(`https://etherscan.io/address/${addressToFund}`)

--- a/src/applications/tribute-tools/commands/fund.unit.test.ts
+++ b/src/applications/tribute-tools/commands/fund.unit.test.ts
@@ -154,7 +154,7 @@ describe('fund unit tests', () => {
       (interactionReplySpy.mock.calls[0][0] as InteractionReplyOptions)
         .embeds?.[0]?.description
     ).toMatch(
-      /📊 \*\*Should we fund `0x04028Df0Cea639E97fDD3fC01bA5CC172613211D` for \$50\.00 USDC\?\*\*/i
+      /📊 \*\*Should we fund `0x04028Df0Cea639E97fDD3fC01bA5CC172613211D` for \$50 USDC\?\*\*/i
     );
 
     expect(

--- a/src/applications/tribute-tools/commands/fund.unit.test.ts
+++ b/src/applications/tribute-tools/commands/fund.unit.test.ts
@@ -12,7 +12,8 @@ import {
   FakeDiscordCommandInteraction,
   GUILD_ID_FIXTURE,
 } from '../../../../test';
-import {BUY_ALLOWED_EMOJIS} from '../config';
+import {prismaMock} from '../../../../test/prismaMock';
+import {THUMBS_EMOJIS} from '../config';
 import {fund} from './fund';
 
 describe('fund unit tests', () => {
@@ -87,6 +88,21 @@ describe('fund unit tests', () => {
     },
   };
 
+  const DB_INSERT_DATA = {
+    addressToFund: ETH_ADDRESS_FIXTURE,
+    amountUSDC: 50000,
+    channelID: '886976610018934824',
+    createdAt: new Date(0),
+    guildID: '722525233755717762',
+    id: 1,
+    messageID: '123456789',
+    processed: false,
+    purpose: 'XYZ Seed Round',
+    upvoteCount: 0,
+    uuid: 'abc123def456',
+    voteThreshold: 3,
+  };
+
   test('should run execute', async () => {
     const client = new Client(CLIENT_OPTIONS);
 
@@ -96,6 +112,15 @@ describe('fund unit tests', () => {
     );
 
     const reactSpy = jest.fn();
+
+    /**
+     * Mock db insert entry
+     *
+     * @todo fix types
+     */
+    (prismaMock.fundAddressPoll as any).create.mockResolvedValue(
+      DB_INSERT_DATA
+    );
 
     const interactionReplySpy = jest
       .spyOn(interaction, 'reply')
@@ -142,8 +167,8 @@ describe('fund unit tests', () => {
     ).toMatch(/3 upvotes/i);
 
     expect(reactSpy).toHaveBeenCalledTimes(2);
-    expect(reactSpy).toHaveBeenNthCalledWith(1, BUY_ALLOWED_EMOJIS[0]);
-    expect(reactSpy).toHaveBeenNthCalledWith(2, BUY_ALLOWED_EMOJIS[1]);
+    expect(reactSpy).toHaveBeenNthCalledWith(1, THUMBS_EMOJIS[0]);
+    expect(reactSpy).toHaveBeenNthCalledWith(2, THUMBS_EMOJIS[1]);
 
     // Cleanup
 

--- a/src/applications/tribute-tools/config.ts
+++ b/src/applications/tribute-tools/config.ts
@@ -35,5 +35,6 @@ export const TRIBUTE_TOOLS_URL: string =
     : 'https://develop--tools-tributelabs.netlify.app';
 
 export const BUY_EXTERNAL_URL: string = `${TRIBUTE_TOOLS_URL}/single-buy`;
+export const FUND_EXTERNAL_URL: string = `${TRIBUTE_TOOLS_URL}/fund`;
 export const SWEEP_EXTERNAL_URL: string = `${TRIBUTE_TOOLS_URL}/floor-sweeper`;
 export const THUMBS_EMOJIS = ['👍', '👎'] as const;

--- a/src/applications/tribute-tools/config.ts
+++ b/src/applications/tribute-tools/config.ts
@@ -36,9 +36,4 @@ export const TRIBUTE_TOOLS_URL: string =
 
 export const BUY_EXTERNAL_URL: string = `${TRIBUTE_TOOLS_URL}/single-buy`;
 export const SWEEP_EXTERNAL_URL: string = `${TRIBUTE_TOOLS_URL}/floor-sweeper`;
-
-/**
- * `/buy` Command Config
- */
-
-export const BUY_ALLOWED_EMOJIS = ['👍', '👎'] as const;
+export const THUMBS_EMOJIS = ['👍', '👎'] as const;

--- a/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.ts
+++ b/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.ts
@@ -11,7 +11,7 @@ import {
 } from 'discord.js';
 import {channelMention, time} from '@discordjs/builders';
 
-import {BUY_ALLOWED_EMOJIS, BUY_EXTERNAL_URL} from '../../config';
+import {THUMBS_EMOJIS, BUY_EXTERNAL_URL} from '../../config';
 import {getDaoDataByGuildID} from '../../../../helpers';
 import {getDaos} from '../../../../services';
 import {prisma} from '../../../../singletons';
@@ -62,11 +62,11 @@ export async function buyPollReactionHandler({
       );
     }
 
-    const isValidEmoji: boolean = BUY_ALLOWED_EMOJIS.some(
+    const isValidEmoji: boolean = THUMBS_EMOJIS.some(
       (name) => name === reaction.emoji.name
     );
 
-    // If the emoji is not from `BUY_ALLOWED_EMOJIS`, remove it.
+    // If the emoji is not from `THUMBS_EMOJIS`, remove it.
     if (!isValidEmoji) {
       await reaction.users.remove(user.id);
 
@@ -146,7 +146,7 @@ export async function buyPollReactionHandler({
     if (
       !processed &&
       voteThreshold > upvoteCount &&
-      (reaction.emoji.name as typeof BUY_ALLOWED_EMOJIS[number]) === '👍'
+      (reaction.emoji.name as typeof THUMBS_EMOJIS[number]) === '👍'
     ) {
       // Add to upvote tally in db
       await prisma.buyNFTPoll.update({

--- a/src/applications/tribute-tools/handlers/buy/buyPollRemoveReactionHandler.ts
+++ b/src/applications/tribute-tools/handlers/buy/buyPollRemoveReactionHandler.ts
@@ -5,7 +5,7 @@ import {
   User,
 } from 'discord.js';
 
-import {BUY_ALLOWED_EMOJIS} from '../../config';
+import {THUMBS_EMOJIS} from '../../config';
 import {prisma} from '../../../../singletons';
 
 export async function buyPollRemoveReactionHandler({
@@ -47,7 +47,7 @@ export async function buyPollRemoveReactionHandler({
     if (
       !processed &&
       voteThreshold > upvoteCount &&
-      (reaction.emoji.name as typeof BUY_ALLOWED_EMOJIS[number]) === '👍'
+      (reaction.emoji.name as typeof THUMBS_EMOJIS[number]) === '👍'
     ) {
       // Subtract from upvote tally in db
       await prisma.buyNFTPoll.update({

--- a/src/applications/tribute-tools/handlers/fund/fundPollReactionHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/fund/fundPollReactionHandler.unit.test.ts
@@ -1,0 +1,861 @@
+import {
+  MessageActionRow,
+  MessageButton,
+  MessageReaction,
+  PartialMessageReaction,
+  PartialUser,
+  User,
+} from 'discord.js';
+
+import {
+  ETH_ADDRESS_FIXTURE,
+  FAKE_DAOS_FIXTURE,
+  GUILD_ID_FIXTURE,
+} from '../../../../../test';
+import {FUND_EXTERNAL_URL} from '../../config';
+import {fundPollReactionHandler} from './fundPollReactionHandler';
+import {prismaMock} from '../../../../../test/prismaMock';
+
+describe('fundPollReactionHandler unit tests', () => {
+  const ERROR_REGEXP =
+    /Something went wrong while handling the Discord reaction: Error: Some bad error/i;
+
+  test('should increment upvotes on upvote', async () => {
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+        reactions: {
+          cache: [],
+        },
+      },
+    } as any;
+
+    const USER: User | PartialUser = {bot: false, id: '123'} as any;
+
+    const DB_ENTRY = {
+      addressToFund: ETH_ADDRESS_FIXTURE,
+      amountUSDC: 50000,
+      channelID: '886976610018934824',
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: 'abc123',
+      processed: false,
+      purpose: 'XYZ Seed Round',
+      upvoteCount: 1,
+      uuid: 'abc123def456',
+      voteThreshold: 3,
+    };
+
+    /**
+     * Mock db return value
+     *
+     * @todo fix types
+     */
+    const dbFindSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateSpy = (
+      prismaMock.fundAddressPoll as any
+    ).update.mockImplementation(async () => {});
+
+    await fundPollReactionHandler({reaction: REACTION, user: USER});
+
+    expect(dbFindSpy).toHaveBeenCalledTimes(1);
+    expect(dbFindSpy).toHaveBeenCalledWith({where: {messageID: 'abc123'}});
+    expect(dbUpdateSpy).toHaveBeenCalledTimes(1);
+
+    expect(dbUpdateSpy.mock.calls[0][0]).toEqual({
+      data: {upvoteCount: 2},
+      where: {messageID: 'abc123'},
+    });
+
+    // Cleanup
+
+    dbFindSpy.mockRestore();
+  });
+
+  test('should handle poll threshold reached', async () => {
+    const channelSendSpy = jest
+      .fn()
+      .mockImplementation(async () => ({url: FUND_EXTERNAL_URL}));
+
+    const messageReplySpy = jest.fn();
+
+    const messageFetchSpy = jest
+      .fn()
+      .mockImplementation(async () => ({reply: messageReplySpy}));
+
+    const channelFetchSpy = jest.fn().mockImplementation(async () => ({
+      messages: {fetch: messageFetchSpy},
+      send: channelSendSpy,
+    }));
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      client: {
+        channels: {
+          fetch: channelFetchSpy,
+        },
+      },
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+        reactions: {
+          cache: [],
+        },
+      },
+    } as any;
+
+    const USER: User | PartialUser = {bot: false, id: '123'} as any;
+
+    const DB_ENTRY = {
+      addressToFund: ETH_ADDRESS_FIXTURE,
+      amountUSDC: 50000,
+      channelID: '886976610018934824',
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: 'abc123',
+      processed: false,
+      purpose: 'XYZ Seed Round',
+      upvoteCount: 2,
+      uuid: 'abc123def456',
+      voteThreshold: 3,
+    };
+
+    const getDaos = await import('../../../../services/dao/getDaos');
+
+    const getDaosSpy = jest
+      .spyOn(getDaos, 'getDaos')
+      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
+
+    /**
+     * Mock db return value
+     *
+     * @todo fix types
+     */
+    const dbFindSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateSpy = (
+      prismaMock.fundAddressPoll as any
+    ).update.mockImplementation(async () => {});
+
+    const BUY_BUTTON = new MessageActionRow().addComponents(
+      new MessageButton()
+        .setLabel('Fund')
+        .setStyle('LINK')
+        .setURL(
+          `${FUND_EXTERNAL_URL}/?daoName=test&amount=${DB_ENTRY.amountUSDC}`
+        )
+        .setEmoji('💸')
+    );
+
+    await fundPollReactionHandler({reaction: REACTION, user: USER});
+
+    expect(dbFindSpy).toHaveBeenCalledTimes(1);
+    expect(dbFindSpy).toHaveBeenCalledWith({where: {messageID: 'abc123'}});
+    expect(dbUpdateSpy).toHaveBeenCalledTimes(2);
+
+    expect(dbUpdateSpy.mock.calls[0][0]).toEqual({
+      data: {upvoteCount: 3},
+      where: {messageID: 'abc123'},
+    });
+
+    expect(dbUpdateSpy.mock.calls[1][0]).toEqual({
+      data: {processed: true},
+      where: {messageID: 'abc123'},
+    });
+
+    // Assert result was posted in the result channel
+
+    expect(channelSendSpy).toHaveBeenCalledTimes(1);
+
+    expect(channelSendSpy.mock.calls[0][0].content).toMatch(
+      /The poll for "\*XYZ Seed Round\*" ended <t:\d+:R>\. The threshold of 3 votes has been reached\./i
+    );
+
+    expect(channelSendSpy.mock.calls[0][0].components).toEqual([BUY_BUTTON]);
+
+    // Assert result was posted in the poll's channel
+
+    expect(messageReplySpy).toHaveBeenCalledTimes(1);
+    expect(messageReplySpy.mock.calls[0][0].embeds[0].title).toMatch(/fund/i);
+
+    expect(messageReplySpy.mock.calls[0][0].embeds[0].url).toBe(
+      FUND_EXTERNAL_URL
+    );
+
+    expect(messageReplySpy.mock.calls[0][0].embeds[0].description).toMatch(
+      /The poll for "\*XYZ Seed Round\*" ended <t:\d+:R>\. The threshold of 3 votes has been reached\./i
+    );
+
+    // Cleanup
+
+    dbFindSpy.mockRestore();
+    dbUpdateSpy.mockRestore();
+    getDaosSpy.mockRestore();
+  });
+
+  test('should exit with no error if dao cannot be found', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation((m) => m);
+
+    const channelSendSpy = jest.fn().mockImplementation(async () => ({}));
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+        reactions: {
+          cache: [],
+        },
+      },
+    } as any;
+
+    const USER: User | PartialUser = {bot: false, id: '123'} as any;
+
+    const DB_ENTRY = {
+      addressToFund: ETH_ADDRESS_FIXTURE,
+      amountUSDC: 50000,
+      channelID: '886976610018934824',
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: 'abc123',
+      processed: false,
+      purpose: 'XYZ Seed Round',
+      upvoteCount: 2,
+      uuid: 'abc123def456',
+      voteThreshold: 3,
+    };
+
+    const getDaos = await import('../../../../services/dao/getDaos');
+
+    const getDaosSpy = jest
+      .spyOn(getDaos, 'getDaos')
+      .mockImplementationOnce(async () => undefined);
+
+    /**
+     * Mock db return value
+     *
+     * @todo fix types
+     */
+    const dbFindSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateSpy = (
+      prismaMock.fundAddressPoll as any
+    ).update.mockImplementation(async () => {});
+
+    await fundPollReactionHandler({reaction: REACTION, user: USER});
+
+    // Assert `console.error` was called
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    expect(consoleErrorSpy.mock.calls[0][0]).toMatch(
+      /Something went wrong while handling the Discord reaction: Error: Could not find DAO by 'guildID' 123123123123123123/i
+    );
+
+    // Assert nothing else was called
+
+    expect(channelSendSpy).toHaveBeenCalledTimes(0);
+
+    // Cleanup
+
+    dbFindSpy.mockRestore();
+    dbUpdateSpy.mockRestore();
+    getDaosSpy.mockRestore();
+  });
+
+  test('should exit with no error if result channel ID cannot be found', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation((m) => m);
+
+    const channelSendSpy = jest.fn().mockImplementation(async () => ({}));
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+        reactions: {
+          cache: [],
+        },
+      },
+    } as any;
+
+    const USER: User | PartialUser = {bot: false, id: '123'} as any;
+
+    const DB_ENTRY = {
+      addressToFund: ETH_ADDRESS_FIXTURE,
+      amountUSDC: 50000,
+      channelID: '886976610018934824',
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: 'abc123',
+      processed: false,
+      purpose: 'XYZ Seed Round',
+      upvoteCount: 2,
+      uuid: 'abc123def456',
+      voteThreshold: 3,
+    };
+
+    const getDaos = await import('../../../../services/dao/getDaos');
+
+    const getDaosSpy = jest
+      .spyOn(getDaos, 'getDaos')
+      .mockImplementationOnce(async () => ({
+        ...FAKE_DAOS_FIXTURE,
+        test: {...FAKE_DAOS_FIXTURE.test, applications: {}},
+      }));
+
+    /**
+     * Mock db return value
+     *
+     * @todo fix types
+     */
+    const dbFindSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateSpy = (
+      prismaMock.fundAddressPoll as any
+    ).update.mockImplementation(async () => {});
+
+    await fundPollReactionHandler({reaction: REACTION, user: USER});
+
+    // Assert `console.error` was called
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    expect(consoleErrorSpy.mock.calls[0][0]).toMatch(
+      /Something went wrong while handling the Discord reaction: Error: Could not find a `resultChannelID`\./i
+    );
+
+    // Assert nothing else was called
+
+    expect(channelSendSpy).toHaveBeenCalledTimes(0);
+
+    // Cleanup
+
+    dbFindSpy.mockRestore();
+    dbUpdateSpy.mockRestore();
+    getDaosSpy.mockRestore();
+  });
+
+  test('should exit with no error if `user` is a bot', () => {
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+      },
+      partial: false,
+    } as any;
+
+    const USER: User | PartialUser = {bot: true, id: '123'} as any;
+
+    fundPollReactionHandler({reaction: REACTION, user: USER});
+  });
+
+  test('should exit with no error if error finding db entry', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation((m) => m);
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+        reactions: {
+          cache: [
+            {
+              emoji: {name: '👍'},
+              users: {
+                cache: new Map().set('123', 'test'),
+              },
+            },
+          ],
+        },
+      },
+    } as any;
+
+    const USER: User | PartialUser = {bot: false, id: '123'} as any;
+
+    /**
+     * Mock db error
+     *
+     * @todo fix types
+     */
+    const dbSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockImplementation(() => {
+      throw new Error('Some bad error');
+    });
+
+    await fundPollReactionHandler({reaction: REACTION, user: USER});
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy.mock.calls[0][0]).toMatch(ERROR_REGEXP);
+
+    // Cleanup
+
+    consoleErrorSpy.mockRestore();
+    dbSpy.mockRestore();
+  });
+
+  test('should exit with no error if error on remove reaction', async () => {
+    const userReactionRemoveSpy = jest.fn().mockImplementation(() => {
+      throw new Error('Some bad error');
+    });
+
+    const userSendSpy = jest.fn();
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+      },
+      partial: false,
+      users: {
+        remove: userReactionRemoveSpy,
+      },
+    } as any;
+
+    const USER: User | PartialUser = {
+      bot: false,
+      discriminator: '1234',
+      id: '123',
+      send: userSendSpy,
+      username: 'testuser',
+    } as any;
+
+    const DB_ENTRY = {
+      addressToFund: ETH_ADDRESS_FIXTURE,
+      amountUSDC: 50000,
+      channelID: '886976610018934824',
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: 'abc123',
+      processed: true,
+      purpose: 'XYZ Seed Round',
+      upvoteCount: 1,
+      uuid: 'abc123def456',
+      voteThreshold: 3,
+    };
+
+    const getDaos = await import('../../../../services/dao/getDaos');
+
+    const getDaosSpy = jest
+      .spyOn(getDaos, 'getDaos')
+      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation((m) => m);
+
+    /**
+     * Mock db return value
+     *
+     * @todo fix types
+     */
+    const dbSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    await fundPollReactionHandler({reaction: REACTION, user: USER});
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    expect(consoleErrorSpy.mock.calls[0][0]?.message).toMatch(
+      /some bad error/i
+    );
+
+    // Assert did not exit function early
+
+    expect(dbSpy).toHaveBeenCalledTimes(1);
+    expect(dbSpy).toHaveBeenCalledWith({where: {messageID: 'abc123'}});
+    expect(getDaosSpy).toHaveBeenCalledTimes(1);
+    expect(userReactionRemoveSpy).toHaveBeenCalledTimes(1);
+    expect(userReactionRemoveSpy).toHaveBeenCalledWith('123');
+    expect(userSendSpy).toHaveBeenCalledTimes(1);
+
+    expect(userSendSpy.mock.calls[0][0]).toMatch(
+      /The poll has ended for \*XYZ Seed Round\*, because the number of required upvotes has been reached\. To purchase, go to <#123123123123123123>\./i
+    );
+
+    // Cleanup
+
+    consoleErrorSpy.mockRestore();
+    dbSpy.mockRestore();
+    getDaosSpy.mockRestore();
+    userReactionRemoveSpy.mockRestore();
+    userSendSpy.mockRestore();
+  });
+
+  test('should exit with no error if error on DM-ing user', async () => {
+    const userReactionRemoveSpy = jest.fn();
+
+    const userSendSpy = jest.fn().mockImplementation(() => {
+      throw new Error('Some bad error');
+    });
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+      },
+      partial: false,
+      users: {
+        remove: userReactionRemoveSpy,
+      },
+    } as any;
+
+    const USER: User | PartialUser = {
+      bot: false,
+      discriminator: '1234',
+      id: '123',
+      send: userSendSpy,
+      username: 'testuser',
+    } as any;
+
+    const DB_ENTRY = {
+      addressToFund: ETH_ADDRESS_FIXTURE,
+      amountUSDC: 50000,
+      channelID: '886976610018934824',
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: 'abc123',
+      processed: true,
+      purpose: 'XYZ Seed Round',
+      upvoteCount: 1,
+      uuid: 'abc123def456',
+      voteThreshold: 3,
+    };
+
+    const getDaos = await import('../../../../services/dao/getDaos');
+
+    const getDaosSpy = jest
+      .spyOn(getDaos, 'getDaos')
+      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation((m) => m);
+
+    /**
+     * Mock db return value
+     *
+     * @todo fix types
+     */
+    const dbSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    await fundPollReactionHandler({reaction: REACTION, user: USER});
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy.mock.calls[0][0]).toMatch(ERROR_REGEXP);
+    expect(dbSpy).toHaveBeenCalledTimes(1);
+    expect(dbSpy).toHaveBeenCalledWith({where: {messageID: 'abc123'}});
+    expect(getDaosSpy).toHaveBeenCalledTimes(1);
+    expect(userReactionRemoveSpy).toHaveBeenCalledTimes(1);
+    expect(userReactionRemoveSpy).toHaveBeenCalledWith('123');
+    expect(userSendSpy).toHaveBeenCalledTimes(1);
+
+    expect(userSendSpy.mock.calls[0][0]).toMatch(
+      /The poll has ended for \*XYZ Seed Round\*, because the number of required upvotes has been reached\. To purchase, go to <#123123123123123123>\./i
+    );
+
+    // Cleanup
+
+    consoleErrorSpy.mockRestore();
+    dbSpy.mockRestore();
+    getDaosSpy.mockRestore();
+    userReactionRemoveSpy.mockRestore();
+    userSendSpy.mockRestore();
+  });
+
+  test('should remove invalid reaction', async () => {
+    const userReactionRemoveSpy = jest.fn();
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      // Invalid emoji option
+      emoji: {name: '🤑'},
+      message: {
+        id: 'abc123',
+      },
+      partial: false,
+      users: {
+        remove: userReactionRemoveSpy,
+      },
+    } as any;
+
+    const USER: User | PartialUser = {bot: false, id: '123'} as any;
+
+    const DB_ENTRY = {
+      addressToFund: ETH_ADDRESS_FIXTURE,
+      amountUSDC: 50000,
+      channelID: '886976610018934824',
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: 'abc123',
+      processed: false,
+      purpose: 'XYZ Seed Round',
+      upvoteCount: 1,
+      uuid: 'abc123def456',
+      voteThreshold: 3,
+    };
+
+    /**
+     * Mock db return value
+     *
+     * @todo fix types
+     */
+    const dbSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    await fundPollReactionHandler({reaction: REACTION, user: USER});
+
+    expect(dbSpy).toHaveBeenCalledTimes(1);
+    expect(dbSpy).toHaveBeenCalledWith({where: {messageID: 'abc123'}});
+    expect(userReactionRemoveSpy).toHaveBeenCalledTimes(1);
+    expect(userReactionRemoveSpy).toHaveBeenCalledWith('123');
+
+    // Cleanup
+
+    dbSpy.mockRestore();
+    userReactionRemoveSpy.mockRestore();
+  });
+
+  test('should remove reaction and send user a message if poll has ended', async () => {
+    const userReactionRemoveSpy = jest.fn();
+    const userSendSpy = jest.fn();
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+      },
+      partial: false,
+      users: {
+        remove: userReactionRemoveSpy,
+      },
+    } as any;
+
+    const USER: User | PartialUser = {
+      bot: false,
+      id: '123',
+      send: userSendSpy,
+    } as any;
+
+    const DB_ENTRY = {
+      addressToFund: ETH_ADDRESS_FIXTURE,
+      amountUSDC: 50000,
+      channelID: '886976610018934824',
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: 'abc123',
+      processed: true,
+      purpose: 'XYZ Seed Round',
+      upvoteCount: 1,
+      uuid: 'abc123def456',
+      voteThreshold: 3,
+    };
+
+    const getDaos = await import('../../../../services/dao/getDaos');
+
+    const getDaosSpy = jest
+      .spyOn(getDaos, 'getDaos')
+      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
+
+    /**
+     * Mock db return value
+     *
+     * @todo fix types
+     */
+    const dbSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    await fundPollReactionHandler({reaction: REACTION, user: USER});
+
+    expect(dbSpy).toHaveBeenCalledTimes(1);
+    expect(dbSpy).toHaveBeenCalledWith({where: {messageID: 'abc123'}});
+    expect(getDaosSpy).toHaveBeenCalledTimes(1);
+    expect(userReactionRemoveSpy).toHaveBeenCalledTimes(1);
+    expect(userReactionRemoveSpy).toHaveBeenCalledWith('123');
+    expect(userSendSpy).toHaveBeenCalledTimes(1);
+
+    expect(userSendSpy.mock.calls[0][0]).toMatch(
+      /The poll has ended for \*XYZ Seed Round\*, because the number of required upvotes has been reached\. To purchase, go to <#123123123123123123>\./i
+    );
+
+    // Cleanup
+
+    dbSpy.mockRestore();
+    getDaosSpy.mockRestore();
+    userReactionRemoveSpy.mockRestore();
+    userSendSpy.mockRestore();
+  });
+
+  test("should only take user's latest reaction", async () => {
+    const userReactionRemoveSpy = jest.fn();
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      // New reaction
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+        reactions: {
+          cache: [
+            {
+              // Old reaction
+              emoji: {name: '👎'},
+              users: {
+                cache: new Map().set('123', 'test'),
+                remove: userReactionRemoveSpy,
+              },
+            },
+          ],
+        },
+      },
+      partial: false,
+    } as any;
+
+    const USER: User | PartialUser = {
+      bot: false,
+      id: '123',
+    } as any;
+
+    const DB_ENTRY = {
+      addressToFund: ETH_ADDRESS_FIXTURE,
+      amountUSDC: 50000,
+      channelID: '886976610018934824',
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: 'abc123',
+      processed: false,
+      purpose: 'XYZ Seed Round',
+      upvoteCount: 1,
+      uuid: 'abc123def456',
+      voteThreshold: 3,
+    };
+
+    /**
+     * Mock db return value
+     *
+     * @todo fix types
+     */
+    const dbSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    await fundPollReactionHandler({reaction: REACTION, user: USER});
+
+    expect(dbSpy).toHaveBeenCalledTimes(1);
+    expect(dbSpy).toHaveBeenCalledWith({where: {messageID: 'abc123'}});
+    expect(userReactionRemoveSpy).toHaveBeenCalledTimes(1);
+    expect(userReactionRemoveSpy).toHaveBeenCalledWith('123');
+
+    // Cleanup
+
+    dbSpy.mockRestore();
+    userReactionRemoveSpy.mockRestore();
+  });
+
+  test('should fetch data if reaction is `partial: true`', async () => {
+    const reactionFetchSpy = jest.fn();
+    const reactionUsersFetchSpy = jest.fn();
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      fetch: reactionFetchSpy,
+      message: {
+        id: 'abc123',
+        reactions: {
+          cache: [
+            {
+              emoji: {name: '👍'},
+              users: {
+                cache: new Map().set('123', 'test'),
+                fetch: reactionUsersFetchSpy,
+              },
+            },
+          ],
+        },
+      },
+      partial: true,
+    } as any;
+
+    const USER: User | PartialUser = {bot: false, id: '123'} as any;
+
+    const DB_ENTRY = {
+      addressToFund: ETH_ADDRESS_FIXTURE,
+      amountUSDC: 50000,
+      channelID: '886976610018934824',
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: 'abc123',
+      processed: false,
+      purpose: 'XYZ Seed Round',
+      upvoteCount: 1,
+      uuid: 'abc123def456',
+      voteThreshold: 3,
+    };
+
+    /**
+     * Mock db return value
+     *
+     * @todo fix types
+     */
+    const dbSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    await fundPollReactionHandler({reaction: REACTION, user: USER});
+
+    expect(reactionFetchSpy).toHaveBeenCalledTimes(1);
+    expect(reactionUsersFetchSpy).toHaveBeenCalledTimes(1);
+
+    // Cleanup
+
+    dbSpy.mockRestore();
+    reactionFetchSpy.mockRestore();
+    reactionUsersFetchSpy.mockRestore();
+  });
+});

--- a/src/applications/tribute-tools/handlers/fund/fundPollRemoveReactionHandler.ts
+++ b/src/applications/tribute-tools/handlers/fund/fundPollRemoveReactionHandler.ts
@@ -1,0 +1,67 @@
+import {
+  MessageReaction,
+  PartialMessageReaction,
+  PartialUser,
+  User,
+} from 'discord.js';
+
+import {THUMBS_EMOJIS} from '../../config';
+import {prisma} from '../../../../singletons';
+
+export async function fundPollRemoveReactionHandler({
+  reaction,
+  user,
+}: {
+  reaction: MessageReaction | PartialMessageReaction;
+  user: User | PartialUser;
+}) {
+  try {
+    // Exit if bot added the reaction (initial reactions on poll creation)
+    if (user.bot) return;
+
+    /**
+     * When a reaction is received, check if the structure is partial
+     * as we may need to `fetch` it, so it can be added to the cache.
+     */
+    if (reaction.partial) {
+      // Fetch the message to add it to the cache
+      await reaction.fetch();
+    }
+
+    const pollEntry = await prisma.fundAddressPoll.findUnique({
+      where: {
+        messageID: reaction.message.id,
+      },
+    });
+
+    // Exit if this is not a poll message
+    if (!pollEntry) {
+      return;
+    }
+
+    const {processed, upvoteCount, voteThreshold} = pollEntry;
+
+    /**
+     * Handle removal of upvote
+     */
+    if (
+      !processed &&
+      voteThreshold > upvoteCount &&
+      (reaction.emoji.name as typeof THUMBS_EMOJIS[number]) === '👍'
+    ) {
+      // Subtract from upvote tally in db
+      await prisma.fundAddressPoll.update({
+        where: {
+          messageID: reaction.message.id,
+        },
+        data: {
+          upvoteCount: pollEntry.upvoteCount - 1,
+        },
+      });
+    }
+  } catch (error) {
+    console.error(
+      `Something went wrong while handling a removed Discord reaction: ${error}`
+    );
+  }
+}

--- a/src/applications/tribute-tools/handlers/fund/fundPollRemoveReactionHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/fund/fundPollRemoveReactionHandler.unit.test.ts
@@ -1,0 +1,250 @@
+import {
+  MessageReaction,
+  PartialMessageReaction,
+  PartialUser,
+  User,
+} from 'discord.js';
+
+import {fundPollRemoveReactionHandler} from './fundPollRemoveReactionHandler';
+import {ETH_ADDRESS_FIXTURE, GUILD_ID_FIXTURE} from '../../../../../test';
+import {prismaMock} from '../../../../../test/prismaMock';
+
+describe('fundPollRemoveReactionHandler unit tests', () => {
+  const ERROR_REGEXP =
+    /Something went wrong while handling a removed Discord reaction: Error: Some bad error/i;
+
+  test('should subtract from upvote count in db', async () => {
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+        reactions: {
+          cache: [],
+        },
+      },
+    } as any;
+
+    const USER: User | PartialUser = {bot: false, id: '123'} as any;
+
+    const DB_ENTRY = {
+      addressToFund: ETH_ADDRESS_FIXTURE,
+      amountUSDC: 50000,
+      channelID: '886976610018934824',
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: 'abc123',
+      processed: false,
+      purpose: 'XYZ Seed Round',
+      upvoteCount: 1,
+      uuid: 'abc123def456',
+      voteThreshold: 3,
+    };
+
+    /**
+     * Mock db find
+     *
+     * @todo fix types
+     */
+    const dbFindSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateSpy = (
+      prismaMock.fundAddressPoll as any
+    ).update.mockImplementation(async () => {});
+
+    await fundPollRemoveReactionHandler({reaction: REACTION, user: USER});
+
+    expect(dbUpdateSpy).toBeCalledTimes(1);
+
+    expect(dbUpdateSpy.mock.calls[0][0]).toEqual({
+      data: {upvoteCount: 0},
+      where: {messageID: DB_ENTRY.messageID},
+    });
+
+    // Cleanup
+
+    dbFindSpy.mockRestore();
+    dbUpdateSpy.mockRestore();
+  });
+
+  test('should exit with no error if `user` is a bot', () => {
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+      },
+      partial: false,
+    } as any;
+
+    const USER: User | PartialUser = {bot: true, id: '123'} as any;
+
+    fundPollRemoveReactionHandler({
+      reaction: REACTION,
+      user: USER,
+    });
+  });
+
+  test('should exit with no error if error finding db entry', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation((m) => m);
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+        reactions: {
+          cache: [],
+        },
+      },
+    } as any;
+
+    const USER: User | PartialUser = {bot: false, id: '123'} as any;
+
+    /**
+     * Mock db error
+     *
+     * @todo fix types
+     */
+    const dbSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockImplementation(() => {
+      throw new Error('Some bad error');
+    });
+
+    await fundPollRemoveReactionHandler({reaction: REACTION, user: USER});
+
+    expect(dbSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy.mock.calls[0][0]).toMatch(ERROR_REGEXP);
+
+    // Cleanup
+
+    consoleErrorSpy.mockRestore();
+    dbSpy.mockRestore();
+  });
+
+  test('should exit with no error if error updating db entry', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation((m) => m);
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      message: {
+        id: 'abc123',
+        reactions: {
+          cache: [],
+        },
+      },
+    } as any;
+
+    const USER: User | PartialUser = {bot: false, id: '123'} as any;
+
+    const DB_ENTRY = {
+      channelID: '886976610018934824',
+      contractAddress: ETH_ADDRESS_FIXTURE,
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: '123456789',
+      name: 'Test Punk #123',
+      processed: false,
+      tokenID: '123',
+      upvoteCount: 2,
+      uuid: 'abc123def456',
+      voteThreshold: 5,
+    };
+
+    /**
+     * Mock db find
+     *
+     * @todo fix types
+     */
+    const dbFindSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateSpy = (
+      prismaMock.fundAddressPoll as any
+    ).update.mockImplementation(() => {
+      throw new Error('Some bad error');
+    });
+
+    await fundPollRemoveReactionHandler({reaction: REACTION, user: USER});
+
+    expect(dbFindSpy).toBeCalledTimes(1);
+    expect(dbUpdateSpy).toBeCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy.mock.calls[0][0]).toMatch(ERROR_REGEXP);
+
+    // Cleanup
+
+    consoleErrorSpy.mockRestore();
+    dbFindSpy.mockRestore();
+    dbUpdateSpy.mockRestore();
+  });
+
+  test('should fetch data if reaction is `partial: true`', async () => {
+    const reactionFetchSpy = jest.fn();
+
+    const REACTION: MessageReaction | PartialMessageReaction = {
+      emoji: {name: '👍'},
+      fetch: reactionFetchSpy,
+      message: {
+        id: 'abc123',
+        reactions: {
+          cache: [],
+        },
+      },
+      partial: true,
+    } as any;
+
+    const USER: User | PartialUser = {bot: false, id: '123'} as any;
+
+    const DB_ENTRY = {
+      channelID: '886976610018934824',
+      contractAddress: ETH_ADDRESS_FIXTURE,
+      createdAt: new Date(0),
+      guildID: GUILD_ID_FIXTURE,
+      id: 1,
+      messageID: '123456789',
+      name: 'Test Punk #123',
+      processed: false,
+      tokenID: '123',
+      upvoteCount: 2,
+      uuid: 'abc123def456',
+      voteThreshold: 5,
+    };
+
+    /**
+     * Mock db return value
+     *
+     * @todo fix types
+     */
+    const dbSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue(DB_ENTRY);
+
+    await fundPollRemoveReactionHandler({reaction: REACTION, user: USER});
+
+    expect(reactionFetchSpy).toHaveBeenCalledTimes(1);
+
+    // Cleanup
+
+    dbSpy.mockRestore();
+    reactionFetchSpy.mockRestore();
+  });
+});

--- a/src/applications/tribute-tools/handlers/fund/index.ts
+++ b/src/applications/tribute-tools/handlers/fund/index.ts
@@ -1,0 +1,2 @@
+export * from './fundPollReactionHandler';
+export * from './fundPollRemoveReactionHandler';

--- a/src/applications/tribute-tools/handlers/index.ts
+++ b/src/applications/tribute-tools/handlers/index.ts
@@ -1,3 +1,4 @@
 export * from './buy';
 export * from './interactionExecuteHandler';
+export * from './fund';
 export * from './sweep';

--- a/src/applications/tribute-tools/main.ts
+++ b/src/applications/tribute-tools/main.ts
@@ -4,12 +4,14 @@ import {
   sweepEndedPollsHandler,
   sweepPollReactionHandler,
 } from './handlers/sweep';
-import {ApplicationReturn} from '../types';
 import {
   buyPollReactionHandler,
   buyPollRemoveReactionHandler,
+  fundPollReactionHandler,
+  fundPollRemoveReactionHandler,
   interactionExecuteHandler,
 } from './handlers';
+import {ApplicationReturn} from '../types';
 import {deployCommands, destroyClientHandler, getCommands} from '../helpers';
 import {getEnv} from '../../helpers';
 import {TRIBUTE_TOOLS_BOT_ID} from '../../config';
@@ -69,11 +71,13 @@ export async function tributeToolsBot(): Promise<
     // Listen to reactions on messages, and possibly handle.
     client.on('messageReactionAdd', (reaction, user) => {
       buyPollReactionHandler({reaction, user});
+      fundPollReactionHandler({reaction, user});
       sweepPollReactionHandler({reaction, user});
     });
 
     // Listen to the removal of reactions on messages, and possibly handle.
     client.on('messageReactionRemove', (reaction, user) => {
+      fundPollRemoveReactionHandler({reaction, user});
       buyPollRemoveReactionHandler({reaction, user});
     });
 

--- a/src/config/applications.ts
+++ b/src/config/applications.ts
@@ -5,7 +5,7 @@ import {APP_ENV} from './common';
  */
 
 export const APPLICATIONS = ['TRIBUTE_TOOLS_BOT'] as const;
-export const APPLICATION_COMMANDS = ['BUY', 'SWEEP'] as const;
+export const APPLICATION_COMMANDS = ['BUY', 'FUND', 'SWEEP'] as const;
 
 /**
  * Application Client IDs

--- a/src/config/daos/daosDevelopment.ts
+++ b/src/config/daos/daosDevelopment.ts
@@ -83,12 +83,7 @@ export const DAOS_DEVELOPMENT: Record<
           FUND: {
             resultChannelID: '933653038718128198',
             // Setting low vote thresholds at `1` required for development
-            voteThresholds: new Map([
-              [[0, 15], 1],
-              [[15, 30], 1],
-              [[30, 100], 1],
-              [[100, 0], 1],
-            ]),
+            voteThreshold: 1,
           },
           SWEEP: {
             resultChannelID: '933653038718128198',

--- a/src/config/daos/daosDevelopment.ts
+++ b/src/config/daos/daosDevelopment.ts
@@ -80,6 +80,16 @@ export const DAOS_DEVELOPMENT: Record<
               [[100, 0], 1],
             ]),
           },
+          FUND: {
+            resultChannelID: '933653038718128198',
+            // Setting low vote thresholds at `1` required for development
+            voteThresholds: new Map([
+              [[0, 15], 1],
+              [[15, 30], 1],
+              [[30, 100], 1],
+              [[100, 0], 1],
+            ]),
+          },
           SWEEP: {
             resultChannelID: '933653038718128198',
           },

--- a/src/config/daos/daosLocalhost.example.ts
+++ b/src/config/daos/daosLocalhost.example.ts
@@ -68,12 +68,7 @@ export const DAOS_LOCALHOST: Record<
           },
           FUND: {
             resultChannelID: '933653038718128198',
-            voteThresholds: new Map([
-              [[0, 15], 1],
-              [[15, 30], 1],
-              [[30, 100], 1],
-              [[100, 0], 1],
-            ]),
+            voteThreshold: 1,
           },
           SWEEP: {
             resultChannelID: '933653038718128198',

--- a/src/config/daos/daosLocalhost.example.ts
+++ b/src/config/daos/daosLocalhost.example.ts
@@ -66,6 +66,15 @@ export const DAOS_LOCALHOST: Record<
               [[100, 0], 1],
             ]),
           },
+          FUND: {
+            resultChannelID: '933653038718128198',
+            voteThresholds: new Map([
+              [[0, 15], 1],
+              [[15, 30], 1],
+              [[30, 100], 1],
+              [[100, 0], 1],
+            ]),
+          },
           SWEEP: {
             resultChannelID: '933653038718128198',
           },

--- a/src/config/daos/daosProduction.ts
+++ b/src/config/daos/daosProduction.ts
@@ -109,6 +109,14 @@ export const DAOS_PRODUCTION: Record<
               [[30, 100], 10],
             ]),
           },
+          FUND: {
+            resultChannelID: '936185841204744222',
+            voteThresholds: new Map([
+              [[0, 15], 3],
+              [[15, 30], 5],
+              [[30, 100], 10],
+            ]),
+          },
           SWEEP: {
             resultChannelID: '936185841204744222',
           },
@@ -137,6 +145,15 @@ export const DAOS_PRODUCTION: Record<
         name: 'TRIBUTE_TOOLS_BOT',
         commands: {
           BUY: {
+            resultChannelID: '938470347521540137',
+            voteThresholds: new Map([
+              [[0, 5], 5],
+              [[5, 30], 10],
+              [[30, 100], 20],
+              [[100, 0], 25],
+            ]),
+          },
+          FUND: {
             resultChannelID: '938470347521540137',
             voteThresholds: new Map([
               [[0, 5], 5],
@@ -185,6 +202,15 @@ export const DAOS_PRODUCTION: Record<
               [[100, 0], 25],
             ]),
           },
+          FUND: {
+            resultChannelID: '936184076107415602',
+            voteThresholds: new Map([
+              [[0, 5], 5],
+              [[5, 30], 10],
+              [[30, 100], 20],
+              [[100, 0], 25],
+            ]),
+          },
           SWEEP: {
             resultChannelID: '936184076107415602',
           },
@@ -210,6 +236,14 @@ export const DAOS_PRODUCTION: Record<
         name: 'TRIBUTE_TOOLS_BOT',
         commands: {
           BUY: {
+            resultChannelID: '936433157832589402',
+            voteThresholds: new Map([
+              [[0, 15], 5],
+              [[15, 30], 10],
+              [[30, 100], 20],
+            ]),
+          },
+          FUND: {
             resultChannelID: '936433157832589402',
             voteThresholds: new Map([
               [[0, 15], 5],

--- a/src/config/daos/daosProduction.ts
+++ b/src/config/daos/daosProduction.ts
@@ -111,11 +111,7 @@ export const DAOS_PRODUCTION: Record<
           },
           FUND: {
             resultChannelID: '936185841204744222',
-            voteThresholds: new Map([
-              [[0, 15], 3],
-              [[15, 30], 5],
-              [[30, 100], 10],
-            ]),
+            voteThreshold: 3,
           },
           SWEEP: {
             resultChannelID: '936185841204744222',
@@ -155,12 +151,7 @@ export const DAOS_PRODUCTION: Record<
           },
           FUND: {
             resultChannelID: '938470347521540137',
-            voteThresholds: new Map([
-              [[0, 5], 5],
-              [[5, 30], 10],
-              [[30, 100], 20],
-              [[100, 0], 25],
-            ]),
+            voteThreshold: 3,
           },
           SWEEP: {
             resultChannelID: '938470347521540137',
@@ -204,12 +195,7 @@ export const DAOS_PRODUCTION: Record<
           },
           FUND: {
             resultChannelID: '936184076107415602',
-            voteThresholds: new Map([
-              [[0, 5], 5],
-              [[5, 30], 10],
-              [[30, 100], 20],
-              [[100, 0], 25],
-            ]),
+            voteThreshold: 3,
           },
           SWEEP: {
             resultChannelID: '936184076107415602',
@@ -245,11 +231,7 @@ export const DAOS_PRODUCTION: Record<
           },
           FUND: {
             resultChannelID: '936433157832589402',
-            voteThresholds: new Map([
-              [[0, 15], 5],
-              [[15, 30], 10],
-              [[30, 100], 20],
-            ]),
+            voteThreshold: 3,
           },
           SWEEP: {
             resultChannelID: '936433157832589402',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -155,16 +155,7 @@ export type TributeToolsCommandsConfiguration = {
   };
 
   FUND: {
-    /**
-     * ```
-     * [
-     *   [[ethMin, ethMax], requiredVotes],
-     *   [[ethMin, ethMax], requiredVotes],
-     *   // ...
-     * ]
-     * ```
-     */
-    voteThresholds: Map<[number, number], number>;
+    voteThreshold: number;
     // Discord channel ID to send a message on poll threshold reached.
     resultChannelID: string;
   };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -153,6 +153,22 @@ export type TributeToolsCommandsConfiguration = {
     // Discord channel ID to send a message on poll threshold reached.
     resultChannelID: string;
   };
+
+  FUND: {
+    /**
+     * ```
+     * [
+     *   [[ethMin, ethMax], requiredVotes],
+     *   [[ethMin, ethMax], requiredVotes],
+     *   // ...
+     * ]
+     * ```
+     */
+    voteThresholds: Map<[number, number], number>;
+    // Discord channel ID to send a message on poll threshold reached.
+    resultChannelID: string;
+  };
+
   SWEEP: {
     // Discord channel ID to send a message on poll end.
     resultChannelID: string;

--- a/test/fixtures/fakeDaos.ts
+++ b/test/fixtures/fakeDaos.ts
@@ -37,6 +37,10 @@ export const FAKE_DAOS_FIXTURE: Record<string, DaoData> = {
               [[100, 0], 20],
             ]),
           },
+          FUND: {
+            resultChannelID: '123123123123123123',
+            voteThreshold: 3,
+          },
           SWEEP: {
             resultChannelID: '123123123123123123',
           },


### PR DESCRIPTION
Fixes #81 

Adds a Discord command called `/fund` which takes a target address and an amount (in USDC) which is to be funded into the address.

🥳 **Adds**

- `fund_address_poll` DB table
- Adds Discord `/fund` command
- Adds handlers for reactions to the poll message
- Adds DAO configuration for `FUND`

🧹 **Chores done**

- `BUY_ALLOWED_EMOJIS`->`THUMBS_EMOJIS`
