### PR TITLE
Adds webhook for sending a poll tx's status

### DIFF
--- a/prisma/migrations/20220223161050_/migration.sql
+++ b/prisma/migrations/20220223161050_/migration.sql
@@ -1,0 +1,14 @@
+-- CreateEnum
+CREATE TYPE "TributeToolsTxStatus" AS ENUM ('failed', 'success');
+
+-- AlterTable
+ALTER TABLE "buy_nft_poll" ADD COLUMN     "txHash" VARCHAR(255),
+ADD COLUMN     "txStatus" "TributeToolsTxStatus";
+
+-- AlterTable
+ALTER TABLE "floor_sweeper_poll" ADD COLUMN     "txHash" VARCHAR(255),
+ADD COLUMN     "txStatus" "TributeToolsTxStatus";
+
+-- AlterTable
+ALTER TABLE "fund_address_poll" ADD COLUMN     "txHash" VARCHAR(255),
+ADD COLUMN     "txStatus" "TributeToolsTxStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,11 @@ generator client {
   provider = "prisma-client-js"
 }
 
+enum TributeToolsTxStatus {
+  failed
+  success
+}
+
 // Models
 // ------
 // @see https://www.prisma.io/docs/concepts/components/prisma-schema/data-model
@@ -26,52 +31,58 @@ model DiscordWebhook {
 }
 
 model FloorSweeperPoll {
-  id              Int      @id @default(autoincrement())
-  uuid            String   @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  createdAt       DateTime @default(now())
-  question        String   @db.VarChar(255)
-  contractAddress String   @db.VarChar(255)
-  dateEnd         DateTime @db.Timestamp(3)
+  id              Int                   @id @default(autoincrement())
+  uuid            String                @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  createdAt       DateTime              @default(now())
+  question        String                @db.VarChar(255)
+  contractAddress String                @db.VarChar(255)
+  dateEnd         DateTime              @db.Timestamp(3)
   options         Json
-  processed       Boolean  @default(false) @db.Boolean
-  result          Int      @default(0) @db.Integer
-  guildID         String   @db.VarChar(255)
-  channelID       String   @db.VarChar(255)
-  messageID       String   @unique @db.VarChar(255)
+  processed       Boolean               @default(false) @db.Boolean
+  result          Int                   @default(0) @db.Integer
+  guildID         String                @db.VarChar(255)
+  channelID       String                @db.VarChar(255)
+  messageID       String                @unique @db.VarChar(255)
+  txStatus        TributeToolsTxStatus?
+  txHash          String?               @db.VarChar(255)
 
   @@map("floor_sweeper_poll")
 }
 
 model BuyNFTPoll {
-  id              Int      @id @default(autoincrement())
-  uuid            String   @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  createdAt       DateTime @default(now())
-  name            String   @db.VarChar(255)
-  contractAddress String   @db.VarChar(255)
-  tokenID         String   @db.VarChar(255)
-  processed       Boolean  @default(false) @db.Boolean
-  voteThreshold   Int      @default(0) @db.Integer
-  upvoteCount     Int      @default(0) @db.Integer
-  guildID         String   @db.VarChar(255)
-  channelID       String   @db.VarChar(255)
-  messageID       String   @unique @db.VarChar(255)
+  id              Int                   @id @default(autoincrement())
+  uuid            String                @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  createdAt       DateTime              @default(now())
+  name            String                @db.VarChar(255)
+  contractAddress String                @db.VarChar(255)
+  tokenID         String                @db.VarChar(255)
+  processed       Boolean               @default(false) @db.Boolean
+  voteThreshold   Int                   @default(0) @db.Integer
+  upvoteCount     Int                   @default(0) @db.Integer
+  guildID         String                @db.VarChar(255)
+  channelID       String                @db.VarChar(255)
+  messageID       String                @unique @db.VarChar(255)
+  txStatus        TributeToolsTxStatus?
+  txHash          String?               @db.VarChar(255)
 
   @@map("buy_nft_poll")
 }
 
 model FundAddressPoll {
-  id            Int      @id @default(autoincrement())
-  uuid          String   @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  createdAt     DateTime @default(now())
-  purpose       String   @db.VarChar(255)
-  addressToFund String   @db.VarChar(255)
-  amountUSDC    Int      @default(0) @db.Integer
-  processed     Boolean  @default(false) @db.Boolean
-  voteThreshold Int      @default(0) @db.Integer
-  upvoteCount   Int      @default(0) @db.Integer
-  guildID       String   @db.VarChar(255)
-  channelID     String   @db.VarChar(255)
-  messageID     String   @unique @db.VarChar(255)
+  id            Int                   @id @default(autoincrement())
+  uuid          String                @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  createdAt     DateTime              @default(now())
+  purpose       String                @db.VarChar(255)
+  addressToFund String                @db.VarChar(255)
+  amountUSDC    Int                   @default(0) @db.Integer
+  processed     Boolean               @default(false) @db.Boolean
+  voteThreshold Int                   @default(0) @db.Integer
+  upvoteCount   Int                   @default(0) @db.Integer
+  guildID       String                @db.VarChar(255)
+  channelID     String                @db.VarChar(255)
+  messageID     String                @unique @db.VarChar(255)
+  txStatus      TributeToolsTxStatus?
+  txHash        String?               @db.VarChar(255)
 
   @@map("fund_address_poll")
 }

--- a/src/http-api/helpers/createHTTPError.ts
+++ b/src/http-api/helpers/createHTTPError.ts
@@ -1,0 +1,26 @@
+import Application from 'koa';
+
+export function createHTTPError({
+  ctx,
+  message,
+  status,
+}: {
+  ctx: Application.ParameterizedContext<
+    Application.DefaultState,
+    Application.DefaultContext,
+    any
+  >;
+  message: string;
+  status: number;
+}) {
+  // Set `ctx.status`
+  ctx.status = status;
+
+  // Set `ctx.body`
+  ctx.body = {
+    error: {
+      message,
+      status,
+    },
+  };
+}

--- a/src/http-api/helpers/createHTTPError.unit.test.ts
+++ b/src/http-api/helpers/createHTTPError.unit.test.ts
@@ -1,0 +1,20 @@
+import {createHTTPError} from '.';
+
+describe('createHTTPError unit tests', () => {
+  test('should create HTTP error', () => {
+    const CTX = {} as Parameters<typeof createHTTPError>['0']['ctx'];
+    const MESSAGE: string = 'Some bad request';
+    const STATUS: number = 400;
+
+    createHTTPError({
+      ctx: CTX,
+      message: MESSAGE,
+      status: STATUS,
+    });
+
+    expect(CTX).toEqual({
+      status: STATUS,
+      body: {error: {message: MESSAGE, status: STATUS}},
+    });
+  });
+});

--- a/src/http-api/helpers/index.ts
+++ b/src/http-api/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './createHTTPError';

--- a/src/http-api/middleware/index.ts
+++ b/src/http-api/middleware/index.ts
@@ -2,3 +2,4 @@ export * from './db';
 export * from './default';
 export * from './health';
 export * from './snapshotWebhook';
+export * from './tributeToolsTxWebhook';

--- a/src/http-api/middleware/tributeToolsTxWebhook.ts
+++ b/src/http-api/middleware/tributeToolsTxWebhook.ts
@@ -1,18 +1,83 @@
+import {Prisma} from '@prisma/client';
 import Application from 'koa';
 
-import {HTTP_API_BASE_PATH} from '../config';
-// import {prisma} from '../../singletons';
-import {normalizeString} from '../../helpers';
 import {
   HTTPMethod,
+  TributeToolsWebhookPayload,
   TributeToolsWebhookTxStatus,
   TributeToolsWebhookTxType,
 } from '../types';
 import {createHTTPError} from '../helpers';
+import {HTTP_API_BASE_PATH} from '../config';
+import {normalizeString} from '../../helpers';
+import {prisma} from '../../singletons';
 
 const PATH: string = 'webhook/tribute-tools-tx';
+
 const NO_BODY_ERROR: string = 'No `body` was provided.';
 const INVALID_BODY_ERROR: string = 'Incorrect `body` was provided.';
+
+async function storeTxData(
+  payload: TributeToolsWebhookPayload
+): Promise<
+  | ReturnType<
+      | typeof prisma.floorSweeperPoll.update
+      | typeof prisma.fundAddressPoll.update
+      | typeof prisma.buyNFTPoll.update
+    >
+  | null
+  | undefined
+> {
+  const {
+    data: {
+      id: uuid,
+      type,
+      tx: {hash: txHash, status: txStatus},
+    },
+  } = payload;
+
+  try {
+    switch (type) {
+      case 'fund':
+        return await prisma.fundAddressPoll.update({
+          data: {txHash, txStatus},
+          where: {uuid},
+        });
+
+      case 'singleBuy':
+        return await prisma.buyNFTPoll.update({
+          data: {txHash, txStatus},
+          where: {uuid},
+        });
+
+      case 'sweep':
+        return await prisma.floorSweeperPoll.update({
+          data: {txHash, txStatus},
+          where: {uuid},
+        });
+
+      default:
+        break;
+    }
+  } catch (error) {
+    console.error(error);
+
+    /**
+     * Handle return if record does not exist
+     *
+     * @see https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
+     */
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error?.code === 'P2025') {
+        return null;
+      }
+    }
+
+    throw new Error(
+      `Something went wrong while saving the transaction data for type \`${type}\` uuid \`${uuid}\`.`
+    );
+  }
+}
 
 export function tributeToolsTxWebhook(): Application.Middleware {
   return async (ctx, next): Promise<void> => {
@@ -23,7 +88,7 @@ export function tributeToolsTxWebhook(): Application.Middleware {
       return await next();
     }
 
-    const body = ctx.request.body;
+    const body = ctx.request.body as TributeToolsWebhookPayload;
 
     // Check body
     if (!body || !Object.keys(body).length) {
@@ -57,7 +122,26 @@ export function tributeToolsTxWebhook(): Application.Middleware {
       return;
     }
 
-    // @todo Store data in database
+    // Store data in database
+    try {
+      const updateResult = await storeTxData(body);
+
+      if (updateResult === null) {
+        createHTTPError({
+          ctx,
+          message: `Could not find uuid \`${body.data.id}\``,
+          status: 404,
+        });
+
+        return;
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        createHTTPError({ctx, message: error.message, status: 500});
+      }
+
+      return;
+    }
 
     ctx.status = 204;
   };

--- a/src/http-api/middleware/tributeToolsTxWebhook.ts
+++ b/src/http-api/middleware/tributeToolsTxWebhook.ts
@@ -1,0 +1,64 @@
+import Application from 'koa';
+
+import {HTTP_API_BASE_PATH} from '../config';
+// import {prisma} from '../../singletons';
+import {normalizeString} from '../../helpers';
+import {
+  HTTPMethod,
+  TributeToolsWebhookTxStatus,
+  TributeToolsWebhookTxType,
+} from '../types';
+import {createHTTPError} from '../helpers';
+
+const PATH: string = 'webhook/tribute-tools-tx';
+const NO_BODY_ERROR: string = 'No `body` was provided.';
+const INVALID_BODY_ERROR: string = 'Incorrect `body` was provided.';
+
+export function tributeToolsTxWebhook(): Application.Middleware {
+  return async (ctx, next): Promise<void> => {
+    if (
+      ctx.path !== `${HTTP_API_BASE_PATH}/${PATH}` ||
+      normalizeString(ctx.method) !== normalizeString(HTTPMethod.POST)
+    ) {
+      return await next();
+    }
+
+    const body = ctx.request.body;
+
+    // Check body
+    if (!body || !Object.keys(body).length) {
+      createHTTPError({ctx, message: NO_BODY_ERROR, status: 400});
+
+      return;
+    }
+
+    const doesTypeMatch: boolean = Object.values(
+      TributeToolsWebhookTxType
+    ).some((t) => t === body?.data?.type);
+
+    const doesTxStatusMatch: boolean = Object.values(
+      TributeToolsWebhookTxStatus
+    ).some((s) => s === body?.data?.tx?.status);
+
+    // Check body payload
+    if (
+      !body?.data ||
+      !body?.data?.id ||
+      !body?.data?.tx ||
+      !body?.data?.tx?.hash ||
+      !body?.data?.tx?.status ||
+      !body?.data?.type ||
+      !doesTxStatusMatch ||
+      !doesTypeMatch ||
+      !Object.keys(body?.data?.tx).length
+    ) {
+      createHTTPError({ctx, message: INVALID_BODY_ERROR, status: 400});
+
+      return;
+    }
+
+    // @todo Store data in database
+
+    ctx.status = 204;
+  };
+}

--- a/src/http-api/middleware/tributeToolsTxWebhook.unit.test.ts
+++ b/src/http-api/middleware/tributeToolsTxWebhook.unit.test.ts
@@ -1,0 +1,256 @@
+import {AddressInfo} from 'node:net';
+import fetch from 'node-fetch';
+
+import {BYTES32_FIXTURE} from '../../../test/fixtures';
+import {HTTP_API_BASE_PATH} from '../config';
+import {httpServer} from '../httpServer';
+
+describe('tributeToolsTxWebhook unit tests', () => {
+  const server = httpServer({noLog: true, useAnyAvailablePort: true});
+
+  async function requestHelper(
+    init: Parameters<typeof fetch>['1'],
+    port: number
+  ) {
+    return await fetch(
+      `http://localhost:${port}${HTTP_API_BASE_PATH}/webhook/tribute-tools-tx`,
+      {
+        headers: {'Content-Type': 'application/json'},
+        method: 'POST',
+        ...init,
+      }
+    );
+  }
+
+  const PAYLOAD = {
+    data: {
+      date: new Date(0),
+      id: 'abc123def456',
+      type: 'sweep',
+      tx: {
+        hash: BYTES32_FIXTURE,
+        status: 'success',
+      },
+    },
+    version: '1.0',
+  };
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  test('should return response when `POST`', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const response = await requestHelper({body: JSON.stringify(PAYLOAD)}, port);
+
+    expect(response.status).toBe(204);
+
+    // Cleanup
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('should return `400` response when no `body`', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const response = await await fetch(
+      `http://localhost:${port}${HTTP_API_BASE_PATH}/webhook/tribute-tools-tx`,
+      {
+        body: JSON.stringify({}),
+        headers: {'Content-Type': 'application/json'},
+        method: 'POST',
+      }
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {message: 'No `body` was provided.', status: 400},
+    });
+
+    // Cleanup
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('should return `400` response when invalid `body`', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const missingDataResponse = await requestHelper(
+      {
+        body: JSON.stringify({
+          bad: {},
+        }),
+      },
+      port
+    );
+
+    // Assert `data` exists
+    expect(missingDataResponse.status).toBe(400);
+    expect(await missingDataResponse.json()).toEqual({
+      error: {message: 'Incorrect `body` was provided.', status: 400},
+    });
+
+    const missingTypeResponse = await requestHelper(
+      {
+        body: JSON.stringify({
+          ...PAYLOAD,
+          data: {...PAYLOAD.data, type: undefined},
+        }),
+      },
+      port
+    );
+
+    // Assert `type` exists
+    expect(missingTypeResponse.status).toBe(400);
+    expect(await missingTypeResponse.json()).toEqual({
+      error: {message: 'Incorrect `body` was provided.', status: 400},
+    });
+
+    const missingIDResponse = await requestHelper(
+      {
+        body: JSON.stringify({
+          ...PAYLOAD,
+          data: {...PAYLOAD.data, id: undefined},
+        }),
+      },
+      port
+    );
+
+    // Assert `type` exists
+    expect(missingIDResponse.status).toBe(400);
+    expect(await missingIDResponse.json()).toEqual({
+      error: {message: 'Incorrect `body` was provided.', status: 400},
+    });
+
+    const typeMatchResponse = await requestHelper(
+      {
+        body: JSON.stringify({
+          ...PAYLOAD,
+          data: {...PAYLOAD.data, type: 'BAD'},
+        }),
+      },
+      port
+    );
+
+    // Assert `type` matches
+    expect(typeMatchResponse.status).toBe(400);
+    expect(await typeMatchResponse.json()).toEqual({
+      error: {message: 'Incorrect `body` was provided.', status: 400},
+    });
+
+    const missingTxResponse = await requestHelper(
+      {
+        body: JSON.stringify({
+          ...PAYLOAD,
+          data: {...PAYLOAD.data, tx: undefined},
+        }),
+      },
+      port
+    );
+
+    // Assert `tx` exists
+    expect(missingTxResponse.status).toBe(400);
+    expect(await missingTxResponse.json()).toEqual({
+      error: {message: 'Incorrect `body` was provided.', status: 400},
+    });
+
+    const emptyTxResponse = await requestHelper(
+      {
+        body: JSON.stringify({
+          ...PAYLOAD,
+          data: {...PAYLOAD.data, tx: {}},
+        }),
+      },
+      port
+    );
+
+    // Assert `tx` is not empty
+    expect(emptyTxResponse.status).toBe(400);
+    expect(await emptyTxResponse.json()).toEqual({
+      error: {message: 'Incorrect `body` was provided.', status: 400},
+    });
+
+    const emptyTxHashResponse = await requestHelper(
+      {
+        body: JSON.stringify({
+          ...PAYLOAD,
+          data: {...PAYLOAD.data, tx: {hash: 'abc123def456'}},
+        }),
+      },
+      port
+    );
+
+    // Assert `tx.status` is not empty
+    expect(emptyTxHashResponse.status).toBe(400);
+    expect(await emptyTxHashResponse.json()).toEqual({
+      error: {message: 'Incorrect `body` was provided.', status: 400},
+    });
+
+    const emptyTxStatusResponse = await requestHelper(
+      {
+        body: JSON.stringify({
+          ...PAYLOAD,
+          data: {...PAYLOAD.data, tx: {status: 'sweep'}},
+        }),
+      },
+      port
+    );
+
+    // Assert `tx.hash` is not empty
+    expect(emptyTxStatusResponse.status).toBe(400);
+    expect(await emptyTxStatusResponse.json()).toEqual({
+      error: {message: 'Incorrect `body` was provided.', status: 400},
+    });
+
+    const txStatusMatchResponse = await requestHelper(
+      {
+        body: JSON.stringify({
+          ...PAYLOAD,
+          data: {...PAYLOAD.data, tx: {status: 'BAD'}},
+        }),
+      },
+      port
+    );
+
+    // Assert `tx.status` matches
+    expect(txStatusMatchResponse.status).toBe(400);
+    expect(await txStatusMatchResponse.json()).toEqual({
+      error: {message: 'Incorrect `body` was provided.', status: 400},
+    });
+
+    // Cleanup
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('should return `404` response when not `POST`', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const response = await await fetch(
+      `http://localhost:${port}${HTTP_API_BASE_PATH}/webhook/tribute-tools-tx`
+    );
+
+    expect(response.status).toBe(404);
+
+    // Cleanup
+    consoleWarnSpy.mockRestore();
+  });
+});

--- a/src/http-api/types.ts
+++ b/src/http-api/types.ts
@@ -9,3 +9,14 @@ export enum HTTPMethod {
   PUT = 'PUT',
   TRACE = 'TRACE',
 }
+
+export enum TributeToolsWebhookTxType {
+  BUY = 'singleBuy',
+  FUND = 'fund',
+  SWEEP = 'sweep',
+}
+
+export enum TributeToolsWebhookTxStatus {
+  FAILED = 'failed',
+  SUCCSS = 'success',
+}

--- a/src/http-api/types.ts
+++ b/src/http-api/types.ts
@@ -16,7 +16,27 @@ export enum TributeToolsWebhookTxType {
   SWEEP = 'sweep',
 }
 
+/**
+ * Types for `POST /webhook/tribute-tools-tx`
+ */
+
 export enum TributeToolsWebhookTxStatus {
   FAILED = 'failed',
-  SUCCSS = 'success',
+  SUCCESS = 'success',
 }
+
+export type TributeToolsWebhookPayload = {
+  data: {
+    date: Date;
+    /**
+     * UUID
+     */
+    id: string;
+    type: TributeToolsWebhookTxType;
+    tx: {
+      hash: string;
+      status: TributeToolsWebhookTxStatus;
+    };
+  };
+  version: string;
+};

--- a/test/fixtures/constants.ts
+++ b/test/fixtures/constants.ts
@@ -5,3 +5,5 @@ export const BYTES32_FIXTURE: string =
   '0xfe837a5e727dacac34d8070a94918f13335f255f9bbf958d876718aac64b299d';
 
 export const GUILD_ID_FIXTURE: string = '123123123123123123';
+
+export const UUID_FIXTURE: string = '02458ff0-4cc5-4137-bcf5-ef91053ab811';


### PR DESCRIPTION
Fixes #87 

🥳 **Adds**

- `POST /webhook/tribute-tools-tx` HTTP API endpoint
- `tributeToolsTxWebhook` API handler
- `createHTTPError` helper
- `TributeToolsWebhookTxType`, `TributeToolsWebhookPayload`, `TributeToolsWebhookTxStatus` types
- `UUID_FIXTURE` test fixture

✨ **Updates**

- `txStatus` column to `floor_sweeper_poll`, `buy_nft_poll`, `fund_address_poll` tables
- `txHash` column to `floor_sweeper_poll`, `buy_nft_poll`, `fund_address_poll` tables

