### PR TITLE
HTTP Endpoints to get submitted transaction data for sweep, buy, fund

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@alch/alchemy-web3": "^1.2.4",
         "@discordjs/rest": "^0.3.0",
+        "@koa/router": "^10.1.1",
         "@prisma/client": "^3.9.2",
         "abi-decoder": "^2.4.0",
         "dayjs": "^1.10.7",
@@ -28,6 +29,7 @@
         "@typechain/web3-v1": "^5.0.0",
         "@types/jest": "^27.4.0",
         "@types/koa": "^2.13.4",
+        "@types/koa__router": "^8.0.11",
         "@types/koa-bodyparser": "^4.3.5",
         "@types/node": "^17.0.19",
         "@types/node-fetch": "^2.6.1",
@@ -1432,6 +1434,26 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@koa/router": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-10.1.1.tgz",
+      "integrity": "sha512-ORNjq5z4EmQPriKbR0ER3k4Gh7YGNhWDL7JBW+8wXDrHLbWYKYSJaOJ9aN06npF5tbTxe2JBOsurpJDAvjiXKw==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "http-errors": "^1.7.3",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@koa/router/node_modules/path-to-regexp": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+      "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
+    },
     "node_modules/@mswjs/cookies": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.6.tgz",
@@ -1810,6 +1832,15 @@
         "@types/keygrip": "*",
         "@types/koa-compose": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/koa__router": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.11.tgz",
+      "integrity": "sha512-WXgKWpBsbS14kzmzD9LeFapOIa678h7zvUHxDwXwSx4ETKXhXLVUAToX6jZ/U7EihM7qwyD9W/BZvB0MRu7MTQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/koa": "*"
       }
     },
     "node_modules/@types/koa-bodyparser": {
@@ -11443,6 +11474,25 @@
         "chalk": "^4.0.0"
       }
     },
+    "@koa/router": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-10.1.1.tgz",
+      "integrity": "sha512-ORNjq5z4EmQPriKbR0ER3k4Gh7YGNhWDL7JBW+8wXDrHLbWYKYSJaOJ9aN06npF5tbTxe2JBOsurpJDAvjiXKw==",
+      "requires": {
+        "debug": "^4.1.1",
+        "http-errors": "^1.7.3",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.1.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+          "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
+        }
+      }
+    },
     "@mswjs/cookies": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.6.tgz",
@@ -11787,6 +11837,15 @@
         "@types/keygrip": "*",
         "@types/koa-compose": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/koa__router": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.11.tgz",
+      "integrity": "sha512-WXgKWpBsbS14kzmzD9LeFapOIa678h7zvUHxDwXwSx4ETKXhXLVUAToX6jZ/U7EihM7qwyD9W/BZvB0MRu7MTQ==",
+      "dev": true,
+      "requires": {
+        "@types/koa": "*"
       }
     },
     "@types/koa-bodyparser": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@alch/alchemy-web3": "^1.2.4",
     "@discordjs/rest": "^0.3.0",
+    "@koa/router": "^10.1.1",
     "@prisma/client": "^3.9.2",
     "abi-decoder": "^2.4.0",
     "dayjs": "^1.10.7",
@@ -58,6 +59,7 @@
     "@typechain/web3-v1": "^5.0.0",
     "@types/jest": "^27.4.0",
     "@types/koa": "^2.13.4",
+    "@types/koa__router": "^8.0.11",
     "@types/koa-bodyparser": "^4.3.5",
     "@types/node": "^17.0.19",
     "@types/node-fetch": "^2.6.1",

--- a/src/http-api/httpServer.ts
+++ b/src/http-api/httpServer.ts
@@ -31,12 +31,12 @@ export function httpServer(options?: HTTPServerOptions): Server {
      */
     app.use(bodyParser());
 
-    // Handle middlware errors
-    app.use(errorHandler());
+    // Handle middleware errors
+    app.use(errorHandler);
 
     // Use all provided HTTP API middleware
     middlewares.forEach((m) => {
-      app.use(m());
+      app.use(m);
     });
 
     // Handle errors from middleware

--- a/src/http-api/httpServer.ts
+++ b/src/http-api/httpServer.ts
@@ -41,7 +41,7 @@ export function httpServer(options?: HTTPServerOptions): Server {
 
     // Handle errors from middleware
     app.on('error', (error, ctx) => {
-      console.error('HTTP API Error from', ctx?.path, error);
+      console.error(`HTTP API Error from ${ctx?.path} ${error}`);
     });
 
     // Start listening

--- a/src/http-api/index.ts
+++ b/src/http-api/index.ts
@@ -1,7 +1,8 @@
 import * as middlewareImports from './middleware';
 import Application from 'koa';
+import Router from '@koa/router';
 
 export * from './httpServer';
 
-export const middlewares: (() => Application.Middleware)[] =
+export const middlewares: (Application.Middleware | Router.Middleware)[] =
   Object.values(middlewareImports);

--- a/src/http-api/middleware/db.ts
+++ b/src/http-api/middleware/db.ts
@@ -5,20 +5,21 @@ import {prisma} from '../../singletons';
 
 const PATH: string = 'db';
 
-export function dbHandler(): Application.Middleware {
-  return async (ctx, next): Promise<void> => {
-    if (ctx.path !== `${HTTP_API_BASE_PATH}/${PATH}`) {
-      return await next();
-    }
+export const dbHandler: Application.Middleware = async (
+  ctx,
+  next
+): Promise<void> => {
+  if (ctx.path !== `${HTTP_API_BASE_PATH}/${PATH}`) {
+    return await next();
+  }
 
-    await prisma.discordWebhook.findFirst({
-      where: {
-        id: {
-          not: undefined,
-        },
+  await prisma.discordWebhook.findFirst({
+    where: {
+      id: {
+        not: undefined,
       },
-    });
+    },
+  });
 
-    ctx.body = 'Database is up and running.';
-  };
-}
+  ctx.body = 'Database is up and running.';
+};

--- a/src/http-api/middleware/default.ts
+++ b/src/http-api/middleware/default.ts
@@ -2,12 +2,13 @@ import Application from 'koa';
 
 import {HTTP_API_BASE_PATH} from '../config';
 
-export function defaultHandler(): Application.Middleware {
-  return async (ctx, next): Promise<void> => {
-    if (ctx.path !== `${HTTP_API_BASE_PATH}`) {
-      return await next();
-    }
+export const defaultHandler: Application.Middleware = async (
+  ctx,
+  next
+): Promise<void> => {
+  if (ctx.path !== `${HTTP_API_BASE_PATH}`) {
+    return await next();
+  }
 
-    ctx.body = 'Hello, I am Tribute Discord Service!';
-  };
-}
+  ctx.body = 'Hello, I am Tribute Discord Service!';
+};

--- a/src/http-api/middleware/error.ts
+++ b/src/http-api/middleware/error.ts
@@ -1,5 +1,7 @@
 import Application from 'koa';
 
+import {createHTTPError} from '../helpers';
+
 // @see https://github.com/koajs/koa/wiki/Error-Handling
 export const errorHandler: Application.Middleware = async (
   ctx,
@@ -8,8 +10,7 @@ export const errorHandler: Application.Middleware = async (
   try {
     await next();
   } catch (error) {
-    ctx.status = 500;
-    ctx.body = (error as Error).message;
+    createHTTPError({ctx, message: (error as Error).message, status: 500});
 
     ctx.app.emit('error', error, ctx);
   }

--- a/src/http-api/middleware/error.ts
+++ b/src/http-api/middleware/error.ts
@@ -1,15 +1,16 @@
 import Application from 'koa';
 
 // @see https://github.com/koajs/koa/wiki/Error-Handling
-export function errorHandler(): Application.Middleware {
-  return async (ctx, next): Promise<void> => {
-    try {
-      await next();
-    } catch (error) {
-      ctx.status = 500;
-      ctx.body = (error as Error).message;
+export const errorHandler: Application.Middleware = async (
+  ctx,
+  next
+): Promise<void> => {
+  try {
+    await next();
+  } catch (error) {
+    ctx.status = 500;
+    ctx.body = (error as Error).message;
 
-      ctx.app.emit('error', error, ctx);
-    }
-  };
-}
+    ctx.app.emit('error', error, ctx);
+  }
+};

--- a/src/http-api/middleware/error.unit.test.ts
+++ b/src/http-api/middleware/error.unit.test.ts
@@ -43,7 +43,16 @@ describe('errorHandler middleware unit tests', () => {
       .spyOn(console, 'warn')
       .mockImplementation(() => {});
 
-    await fetch(`http://localhost:${port}${HTTP_API_BASE_PATH}/bad`);
+    expect(
+      await (
+        await fetch(`http://localhost:${port}${HTTP_API_BASE_PATH}/bad`)
+      ).json()
+    ).toEqual({
+      error: {
+        message: 'Yikes, an error!',
+        status: 500,
+      },
+    });
 
     // Assert error message matches
     expect(assertErrorMessage).toMatch(/yikes, an error!/i);

--- a/src/http-api/middleware/error.unit.test.ts
+++ b/src/http-api/middleware/error.unit.test.ts
@@ -17,7 +17,7 @@ describe('errorHandler middleware unit tests', () => {
 
     const {port} = server?.address() as AddressInfo;
 
-    app.use(errorHandler());
+    app.use(errorHandler);
 
     app.use(async function badMiddleware(ctx, next) {
       if (ctx.path !== `${HTTP_API_BASE_PATH}/bad`) {
@@ -71,7 +71,7 @@ describe('errorHandler middleware unit tests', () => {
 
     const {port} = server?.address() as AddressInfo;
 
-    app.use(errorHandler());
+    app.use(errorHandler);
 
     app.use(async function badMiddleware(ctx, next) {
       if (ctx.path !== `${HTTP_API_BASE_PATH}/bad`) {

--- a/src/http-api/middleware/health.ts
+++ b/src/http-api/middleware/health.ts
@@ -4,12 +4,13 @@ import {HTTP_API_BASE_PATH} from '../config';
 
 const PATH: string = 'health';
 
-export function healthHandler(): Application.Middleware {
-  return async (ctx, next): Promise<void> => {
-    if (ctx.path !== `${HTTP_API_BASE_PATH}/${PATH}`) {
-      return await next();
-    }
+export const healthHandler: Application.Middleware = async (
+  ctx,
+  next
+): Promise<void> => {
+  if (ctx.path !== `${HTTP_API_BASE_PATH}/${PATH}`) {
+    return await next();
+  }
 
-    ctx.body = 'HTTP API is up and running.';
-  };
-}
+  ctx.body = 'HTTP API is up and running.';
+};

--- a/src/http-api/middleware/index.ts
+++ b/src/http-api/middleware/index.ts
@@ -2,4 +2,4 @@ export * from './db';
 export * from './default';
 export * from './health';
 export * from './snapshotWebhook';
-export * from './tributeToolsTxWebhook';
+export * from './tributeTools';

--- a/src/http-api/middleware/snapshotWebhook.ts
+++ b/src/http-api/middleware/snapshotWebhook.ts
@@ -7,20 +7,21 @@ import {snapshotProposalEventRunner} from '../../webhook-tasks/runners/snapshotH
 
 const PATH: string = 'snapshot-webhook';
 
-export function snapshotWebhookHandler(): Application.Middleware {
-  return async (ctx, next): Promise<void> => {
-    if (
-      ctx.path !== `${HTTP_API_BASE_PATH}/${PATH}` ||
-      normalizeString(ctx.method) !== normalizeString(HTTPMethod.POST)
-    ) {
-      return await next();
-    }
+export const snapshotWebhookHandler: Application.Middleware = async (
+  ctx,
+  next
+): Promise<void> => {
+  if (
+    ctx.path !== `${HTTP_API_BASE_PATH}/${PATH}` ||
+    normalizeString(ctx.method) !== normalizeString(HTTPMethod.POST)
+  ) {
+    return await next();
+  }
 
-    ctx.status = 202;
+  ctx.status = 202;
 
-    // `koa-bodyparser` returns an empty object if no `body`
-    if (!Object.keys(ctx.request.body).length) return;
+  // `koa-bodyparser` returns an empty object if no `body`
+  if (!Object.keys(ctx.request.body).length) return;
 
-    await snapshotProposalEventRunner(ctx.request.body);
-  };
-}
+  await snapshotProposalEventRunner(ctx.request.body);
+};

--- a/src/http-api/middleware/tributeTools/index.ts
+++ b/src/http-api/middleware/tributeTools/index.ts
@@ -1,0 +1,2 @@
+export * from './router';
+export * from './tributeToolsTxWebhook';

--- a/src/http-api/middleware/tributeTools/router.ts
+++ b/src/http-api/middleware/tributeTools/router.ts
@@ -1,10 +1,11 @@
 import Router from '@koa/router';
 
 import {HTTP_API_BASE_PATH} from '../../config';
+import {tributeToolsGetDaoTxs} from './tributeToolsGetDaoTxs';
 import {tributeToolsGetTx} from './tributeToolsGetTx';
 
 /**
- * Koa Router Instance
+ * Koa `Router` Instance
  *
  * @note `prefix` is set
  */
@@ -13,13 +14,14 @@ const tributeToolsRouter = new Router({
 });
 
 /**
- * Register routes
+ * Register `@koa/router` routes
  */
 
+tributeToolsGetDaoTxs(tributeToolsRouter);
 tributeToolsGetTx(tributeToolsRouter);
 
 /**
- * Export routes
+ * Export `@koa/router` routes
  */
 
 export const tributeToolsRouterRoutes = tributeToolsRouter.routes();

--- a/src/http-api/middleware/tributeTools/router.ts
+++ b/src/http-api/middleware/tributeTools/router.ts
@@ -1,0 +1,25 @@
+import Router from '@koa/router';
+
+import {HTTP_API_BASE_PATH} from '../../config';
+import {tributeToolsGetTx} from './tributeToolsGetTx';
+
+/**
+ * Koa Router Instance
+ *
+ * @note `prefix` is set
+ */
+const tributeToolsRouter = new Router({
+  prefix: `${HTTP_API_BASE_PATH}/tribute-tools`,
+});
+
+/**
+ * Register routes
+ */
+
+tributeToolsGetTx(tributeToolsRouter);
+
+/**
+ * Export routes
+ */
+
+export const tributeToolsRouterRoutes = tributeToolsRouter.routes();

--- a/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.ts
@@ -1,10 +1,126 @@
+import {TributeToolsTxStatus} from '@prisma/client';
+import {z} from 'zod';
 import Router from '@koa/router';
+
+import {createHTTPError} from '../../helpers';
+import {getDaos} from '../../../services';
+import {normalizeString} from '../../../helpers';
+import {prisma} from '../../../singletons';
+import {TributeToolsWebhookTxType} from '../../types';
+
+type TributeToolsGetDaoTxParams = {
+  daoName: string;
+  type: TributeToolsWebhookTxType;
+};
 
 const PATH: string = '/tx/dao/:daoName/:type';
 
+const RequiredParamsSchema = z.object({
+  daoName: z.string(),
+  type: z.nativeEnum(TributeToolsWebhookTxType),
+});
+
+const INVALID_PARAMS_ERROR: string = 'The provided parameters are invalid.';
+const DAO_NOT_FOUND_ERROR: string = 'The DAO could not be found.';
+
+/**
+ * Validate JSON Schema
+ *
+ * @param data
+ * @returns `TributeToolsGetDaoTxParams`
+ * @see https://github.com/colinhacks/zod
+ * @see https://2ality.com/2020/06/validating-data-typescript.html#example%3A-validating-data-via-the-library-zod
+ */
+function validateParams(data: unknown): TributeToolsGetDaoTxParams {
+  // Return data, or throw.
+  return RequiredParamsSchema.parse(data);
+}
+
+async function getTxData(params: {
+  guildID: string;
+  type: TributeToolsWebhookTxType;
+}): Promise<
+  | {
+      txStatus: TributeToolsTxStatus | null;
+      txHash: string | null;
+    }[]
+  | undefined
+  | null
+> {
+  const {guildID, type} = params;
+
+  try {
+    switch (type) {
+      case 'fund':
+        return await prisma.fundAddressPoll.findMany({
+          select: {txStatus: true, txHash: true},
+          where: {guildID, NOT: [{txHash: null}, {txStatus: null}]},
+        });
+
+      case 'singleBuy':
+        return await prisma.buyNFTPoll.findMany({
+          select: {txStatus: true, txHash: true},
+          where: {guildID, NOT: [{txHash: null}, {txStatus: null}]},
+        });
+
+      case 'sweep':
+        return await prisma.floorSweeperPoll.findMany({
+          select: {txStatus: true, txHash: true},
+          where: {guildID, NOT: [{txHash: null}, {txStatus: null}]},
+        });
+
+      default:
+        break;
+    }
+  } catch (error) {
+    console.error(error);
+
+    throw new Error(
+      `Something went wrong while getting the transaction data for type \`${type}\`.`
+    );
+  }
+}
+
 export const tributeToolsGetDaoTxs = (router: Router) => {
-  router.get(PATH, async (ctx, next) => {
+  router.get(PATH, async (ctx) => {
+    let validatedParams: TributeToolsGetDaoTxParams;
+
+    try {
+      validatedParams = validateParams(ctx.params);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        console.error(
+          `Invalid parameters provided to ${PATH}: ${JSON.stringify(
+            error.issues,
+            null,
+            2
+          )}`
+        );
+      }
+
+      createHTTPError({ctx, message: INVALID_PARAMS_ERROR, status: 400});
+
+      return;
+    }
+
+    const dao = Object.entries((await getDaos()) || {}).find(
+      ([_, data]) =>
+        normalizeString(data.internalName) ===
+        normalizeString(validatedParams.daoName)
+    )?.[1];
+
+    if (!dao) {
+      createHTTPError({ctx, message: DAO_NOT_FOUND_ERROR, status: 404});
+
+      return;
+    }
+
+    const result = await getTxData({
+      guildID: dao.guildID,
+      type: validatedParams.type,
+    });
+
     ctx.status = 200;
-    ctx.body = 'DAO';
+    ctx.body = result;
   });
 };

--- a/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.ts
@@ -1,0 +1,15 @@
+import Application from 'koa';
+
+import {HTTP_API_BASE_PATH} from '../../config';
+
+const PATH: string = '/tx/dao/:daoName/:type';
+
+export function tributeToolsGetDaoTxs(): Application.Middleware {
+  return async (ctx, next): Promise<void> => {
+    if (ctx.path !== `${HTTP_API_BASE_PATH}/${PATH}`) {
+      return await next();
+    }
+
+    ctx.status = 200;
+  };
+}

--- a/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.ts
@@ -1,15 +1,10 @@
-import Application from 'koa';
-
-import {HTTP_API_BASE_PATH} from '../../config';
+import Router from '@koa/router';
 
 const PATH: string = '/tx/dao/:daoName/:type';
 
-export function tributeToolsGetDaoTxs(): Application.Middleware {
-  return async (ctx, next): Promise<void> => {
-    if (ctx.path !== `${HTTP_API_BASE_PATH}/${PATH}`) {
-      return await next();
-    }
-
+export const tributeToolsGetDaoTxs = (router: Router) => {
+  router.get(PATH, async (ctx, next) => {
     ctx.status = 200;
-  };
-}
+    ctx.body = 'DAO';
+  });
+};

--- a/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.unit.test.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.unit.test.ts
@@ -66,7 +66,7 @@ describe('tributeToolsGetDaoTx unit tests', () => {
 
     const getDaosSpy = jest
       .spyOn(getDaos, 'getDaos')
-      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
+      .mockImplementation(async () => FAKE_DAOS_FIXTURE);
 
     // Temporarily hide warnings from `msw`
     const consoleWarnSpy = jest
@@ -143,7 +143,7 @@ describe('tributeToolsGetDaoTx unit tests', () => {
 
     const getDaosSpy = jest
       .spyOn(getDaos, 'getDaos')
-      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
+      .mockImplementation(async () => FAKE_DAOS_FIXTURE);
 
     // Temporarily hide warnings from `msw`
     const consoleWarnSpy = jest
@@ -192,7 +192,7 @@ describe('tributeToolsGetDaoTx unit tests', () => {
 
     const getDaosSpy = jest
       .spyOn(getDaos, 'getDaos')
-      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
+      .mockImplementation(async () => FAKE_DAOS_FIXTURE);
 
     // Temporarily hide warnings from `msw`
     const consoleWarnSpy = jest
@@ -257,7 +257,7 @@ describe('tributeToolsGetDaoTx unit tests', () => {
 
     const getDaosSpy = jest
       .spyOn(getDaos, 'getDaos')
-      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
+      .mockImplementation(async () => FAKE_DAOS_FIXTURE);
 
     // Temporarily hide warnings from `msw`
     const consoleWarnSpy = jest

--- a/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.unit.test.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.unit.test.ts
@@ -188,6 +188,12 @@ describe('tributeToolsGetDaoTx unit tests', () => {
       },
     });
 
+    const getDaos = await import('../../../services/dao/getDaos');
+
+    const getDaosSpy = jest
+      .spyOn(getDaos, 'getDaos')
+      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
+
     // Temporarily hide warnings from `msw`
     const consoleWarnSpy = jest
       .spyOn(console, 'warn')
@@ -230,6 +236,7 @@ describe('tributeToolsGetDaoTx unit tests', () => {
     buyNFTPollSpy.mockRestore();
     consoleErrorSpy.mockRestore();
     consoleWarnSpy.mockRestore();
+    getDaosSpy.mockRestore();
   });
 
   test('should return server error', async () => {
@@ -245,6 +252,12 @@ describe('tributeToolsGetDaoTx unit tests', () => {
     ).findMany.mockImplementation(() => {
       throw new Error('Some bad error.');
     });
+
+    const getDaos = await import('../../../services/dao/getDaos');
+
+    const getDaosSpy = jest
+      .spyOn(getDaos, 'getDaos')
+      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
 
     // Temporarily hide warnings from `msw`
     const consoleWarnSpy = jest
@@ -285,5 +298,6 @@ describe('tributeToolsGetDaoTx unit tests', () => {
     buyNFTPollSpy.mockRestore();
     consoleErrorSpy.mockRestore();
     consoleWarnSpy.mockRestore();
+    getDaosSpy.mockRestore();
   });
 });

--- a/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.unit.test.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetDaoTxs.unit.test.ts
@@ -1,0 +1,289 @@
+import {AddressInfo} from 'node:net';
+import fetch from 'node-fetch';
+
+import {BYTES32_FIXTURE, FAKE_DAOS_FIXTURE} from '../../../../test/fixtures';
+import {HTTP_API_BASE_PATH} from '../../config';
+import {httpServer} from '../..';
+import {prismaMock} from '../../../../test/prismaMock';
+import {TributeToolsWebhookTxType} from '../../types';
+
+describe('tributeToolsGetDaoTx unit tests', () => {
+  const server = httpServer({noLog: true, useAnyAvailablePort: true});
+
+  function zodErrorHelper(errorMessage: string): Record<string, any>[] {
+    const errors = errorMessage.split(
+      /Invalid parameters provided to \/tx\/dao\/:daoName\/:type:/i
+    )[1];
+
+    if (!errors) return [];
+
+    return JSON.parse(errors);
+  }
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  test('should return result', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    /**
+     * Mock results
+     *
+     * @todo Fix types
+     */
+
+    const buyNFTPollSpy = (
+      prismaMock.buyNFTPoll as any
+    ).findMany.mockResolvedValue([
+      {
+        txStatus: 'success',
+        txHash: BYTES32_FIXTURE,
+      },
+    ]);
+
+    const sweepNFTPollSpy = (
+      prismaMock.floorSweeperPoll as any
+    ).findMany.mockResolvedValue([
+      {
+        txStatus: 'success',
+        txHash:
+          '0x295cc18927e6cf72bf0103c9df4ec3507f76ea1a42721be38ee5cc8a0cd627da',
+      },
+    ]);
+
+    const fundNFTPollSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findMany.mockResolvedValue([
+      {
+        txStatus: 'success',
+        txHash:
+          '0x70477c8ad25fc880f2ad49c09c4c04ca8e4a31082ae36214c80044e045f4f549',
+      },
+    ]);
+
+    const getDaos = await import('../../../services/dao/getDaos');
+
+    const getDaosSpy = jest
+      .spyOn(getDaos, 'getDaos')
+      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    // Assert buy result
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/dao/test/${TributeToolsWebhookTxType.BUY}`
+        )
+      ).json()
+    ).toEqual([
+      {
+        txStatus: 'success',
+        txHash:
+          '0xfe837a5e727dacac34d8070a94918f13335f255f9bbf958d876718aac64b299d',
+      },
+    ]);
+
+    // Assert sweep result
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/dao/test/${TributeToolsWebhookTxType.SWEEP}`
+        )
+      ).json()
+    ).toEqual([
+      {
+        txStatus: 'success',
+        txHash:
+          '0x295cc18927e6cf72bf0103c9df4ec3507f76ea1a42721be38ee5cc8a0cd627da',
+      },
+    ]);
+
+    // Assert fund result
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/dao/test/${TributeToolsWebhookTxType.FUND}`
+        )
+      ).json()
+    ).toEqual([
+      {
+        txStatus: 'success',
+        txHash:
+          '0x70477c8ad25fc880f2ad49c09c4c04ca8e4a31082ae36214c80044e045f4f549',
+      },
+    ]);
+
+    // Cleanup
+
+    buyNFTPollSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    fundNFTPollSpy.mockRestore();
+    getDaosSpy.mockRestore();
+    sweepNFTPollSpy.mockRestore();
+  });
+
+  test('should return not found if no DAO found', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    /**
+     * Mock result
+     *
+     * @todo Fix types
+     */
+    const buyNFTPollSpy = (
+      prismaMock.buyNFTPoll as any
+    ).findMany.mockResolvedValue(undefined);
+
+    const getDaos = await import('../../../services/dao/getDaos');
+
+    const getDaosSpy = jest
+      .spyOn(getDaos, 'getDaos')
+      .mockImplementationOnce(async () => FAKE_DAOS_FIXTURE);
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    // Assert result
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/dao/bad-name/${TributeToolsWebhookTxType.BUY}`
+        )
+      ).json()
+    ).toEqual({
+      error: {
+        message: 'The DAO could not be found.',
+        status: 404,
+      },
+    });
+
+    // Cleanup
+
+    buyNFTPollSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    getDaosSpy.mockRestore();
+  });
+
+  test('should return bad request if params are not valid', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    /**
+     * Mock result
+     *
+     * @todo Fix types
+     */
+    const buyNFTPollSpy = (
+      prismaMock.buyNFTPoll as any
+    ).findMany.mockResolvedValue({
+      error: {
+        message: 'The provided parameters are invalid.',
+        status: 400,
+      },
+    });
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/dao/test/bad-type`
+        )
+      ).json()
+    ).toEqual({
+      error: {
+        message: 'The provided parameters are invalid.',
+        status: 400,
+      },
+    });
+
+    // Assert `:type` param invalid
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    expect(zodErrorHelper(consoleErrorSpy.mock.calls[0][0])).toEqual([
+      {
+        code: 'invalid_enum_value',
+        message: "Invalid enum value. Expected 'singleBuy' | 'fund' | 'sweep'",
+        options: ['singleBuy', 'fund', 'sweep'],
+        path: ['type'],
+      },
+    ]);
+
+    // Assert log call count
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    // Cleanup
+
+    buyNFTPollSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('should return server error', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    /**
+     * Mock result
+     *
+     * @todo Fix types
+     */
+    const buyNFTPollSpy = (
+      prismaMock.buyNFTPoll as any
+    ).findMany.mockImplementation(() => {
+      throw new Error('Some bad error.');
+    });
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    // Assert result
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/dao/test/${TributeToolsWebhookTxType.BUY}`
+        )
+      ).json()
+    ).toEqual({
+      error: {
+        message: `Something went wrong while getting the transaction data for type \`${TributeToolsWebhookTxType.BUY}\`.`,
+        status: 500,
+      },
+    });
+
+    // Assert `console.error`
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+
+    expect(consoleErrorSpy.mock.calls[0][0]?.message).toMatch(
+      /some bad error/i
+    );
+
+    expect(consoleErrorSpy.mock.calls[1][0]).toMatch(
+      /HTTP API Error from \/api\/tribute-tools\/tx\/dao\/test\/singleBuy Error: Something went wrong while getting the transaction data for type \`singleBuy\`\./i
+    );
+
+    // Cleanup
+
+    buyNFTPollSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+});

--- a/src/http-api/middleware/tributeTools/tributeToolsGetTx.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetTx.ts
@@ -2,8 +2,8 @@ import {z} from 'zod';
 import Router from '@koa/router';
 
 import {createHTTPError} from '../../helpers';
-import {FundAddressPoll} from '@prisma/client';
 import {prisma} from '../../../singletons';
+import {TributeToolsTxStatus} from '@prisma/client';
 import {TributeToolsWebhookTxType} from '../../types';
 
 type TributeToolsGetTxParams = {
@@ -36,8 +36,8 @@ function validateParams(data: unknown): TributeToolsGetTxParams {
 
 async function getTxData(params: TributeToolsGetTxParams): Promise<
   | {
-      txStatus: FundAddressPoll['txStatus'] | null;
-      txHash: FundAddressPoll['txHash'] | null;
+      txStatus: TributeToolsTxStatus | null;
+      txHash: string | null;
     }
   | undefined
   | null

--- a/src/http-api/middleware/tributeTools/tributeToolsGetTx.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetTx.ts
@@ -1,0 +1,10 @@
+import Router from '@koa/router';
+
+const PATH: string = '/tx/:type/:uuid';
+
+export const tributeToolsGetTx = (router: Router) => {
+  router.get(PATH, async (ctx, next) => {
+    ctx.status = 200;
+    ctx.body = 'COol';
+  });
+};

--- a/src/http-api/middleware/tributeTools/tributeToolsGetTx.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetTx.ts
@@ -1,10 +1,112 @@
+import {z} from 'zod';
 import Router from '@koa/router';
+
+import {createHTTPError} from '../../helpers';
+import {FundAddressPoll} from '@prisma/client';
+import {prisma} from '../../../singletons';
+import {TributeToolsWebhookTxType} from '../../types';
+
+type TributeToolsGetTxParams = {
+  type: TributeToolsWebhookTxType;
+  uuid: string;
+};
 
 const PATH: string = '/tx/:type/:uuid';
 
+const RequiredParamsSchema = z.object({
+  type: z.nativeEnum(TributeToolsWebhookTxType),
+  uuid: z.string().uuid(),
+});
+
+const INVALID_PARAMS_ERROR: string = 'The provided parameters are invalid.';
+const NOT_FOUND_ERROR: string = 'The transaction was not found.';
+
+/**
+ * Validate JSON Schema
+ *
+ * @param data
+ * @returns `TributeToolsGetTxParams`
+ * @see https://github.com/colinhacks/zod
+ * @see https://2ality.com/2020/06/validating-data-typescript.html#example%3A-validating-data-via-the-library-zod
+ */
+function validateParams(data: unknown): TributeToolsGetTxParams {
+  // Return data, or throw.
+  return RequiredParamsSchema.parse(data);
+}
+
+async function getTxData(params: TributeToolsGetTxParams): Promise<
+  | {
+      txStatus: FundAddressPoll['txStatus'] | null;
+      txHash: FundAddressPoll['txHash'] | null;
+    }
+  | undefined
+  | null
+> {
+  const {uuid, type} = params;
+
+  try {
+    switch (type) {
+      case 'fund':
+        return await prisma.fundAddressPoll.findUnique({
+          select: {txStatus: true, txHash: true},
+          where: {uuid},
+        });
+
+      case 'singleBuy':
+        return await prisma.buyNFTPoll.findUnique({
+          select: {txStatus: true, txHash: true},
+          where: {uuid},
+        });
+
+      case 'sweep':
+        return await prisma.floorSweeperPoll.findUnique({
+          select: {txStatus: true, txHash: true},
+          where: {uuid},
+        });
+
+      default:
+        break;
+    }
+  } catch (error) {
+    console.error(error);
+
+    throw new Error(
+      `Something went wrong while getting the transaction data for type \`${type}\` uuid \`${uuid}\`.`
+    );
+  }
+}
+
 export const tributeToolsGetTx = (router: Router) => {
-  router.get(PATH, async (ctx, next) => {
+  router.get(PATH, async (ctx) => {
+    let validatedParams: TributeToolsGetTxParams;
+
+    try {
+      validatedParams = validateParams(ctx.params);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        console.error(
+          `Invalid parameters provided to ${PATH}: ${JSON.stringify(
+            error.issues,
+            null,
+            2
+          )}`
+        );
+      }
+
+      createHTTPError({ctx, message: INVALID_PARAMS_ERROR, status: 400});
+
+      return;
+    }
+
+    const result = await getTxData(validatedParams);
+
+    if (!result) {
+      createHTTPError({ctx, message: NOT_FOUND_ERROR, status: 404});
+
+      return;
+    }
+
     ctx.status = 200;
-    ctx.body = 'COol';
+    ctx.body = result;
   });
 };

--- a/src/http-api/middleware/tributeTools/tributeToolsGetTx.unit.test.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetTx.unit.test.ts
@@ -1,0 +1,3 @@
+describe('tributeToolsGetTx unit tests', () => {
+  test('should', () => {});
+});

--- a/src/http-api/middleware/tributeTools/tributeToolsGetTx.unit.test.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetTx.unit.test.ts
@@ -1,3 +1,282 @@
+import {AddressInfo} from 'node:net';
+import fetch from 'node-fetch';
+
+import {BYTES32_FIXTURE, UUID_FIXTURE} from '../../../../test/fixtures';
+import {HTTP_API_BASE_PATH} from '../../config';
+import {httpServer} from '../..';
+import {prismaMock} from '../../../../test/prismaMock';
+import {TributeToolsWebhookTxType} from '../../types';
+
 describe('tributeToolsGetTx unit tests', () => {
-  test('should', () => {});
+  const server = httpServer({noLog: true, useAnyAvailablePort: true});
+
+  function zodErrorHelper(errorMessage: string): Record<string, any>[] {
+    const errors = errorMessage.split(
+      /Invalid parameters provided to \/tx\/:type\/:uuid:/i
+    )[1];
+
+    return JSON.parse(errors);
+  }
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  test('should return result', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    /**
+     * Mock results
+     *
+     * @todo Fix types
+     */
+
+    const buyNFTPollSpy = (
+      prismaMock.buyNFTPoll as any
+    ).findUnique.mockResolvedValue({
+      txStatus: 'success',
+      txHash: BYTES32_FIXTURE,
+    });
+
+    const sweepNFTPollSpy = (
+      prismaMock.floorSweeperPoll as any
+    ).findUnique.mockResolvedValue({
+      txStatus: 'success',
+      txHash:
+        '0x295cc18927e6cf72bf0103c9df4ec3507f76ea1a42721be38ee5cc8a0cd627da',
+    });
+
+    const fundNFTPollSpy = (
+      prismaMock.fundAddressPoll as any
+    ).findUnique.mockResolvedValue({
+      txStatus: 'success',
+      txHash:
+        '0x70477c8ad25fc880f2ad49c09c4c04ca8e4a31082ae36214c80044e045f4f549',
+    });
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    // Assert buy result
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/${TributeToolsWebhookTxType.BUY}/${UUID_FIXTURE}`
+        )
+      ).json()
+    ).toEqual({
+      txStatus: 'success',
+      txHash:
+        '0xfe837a5e727dacac34d8070a94918f13335f255f9bbf958d876718aac64b299d',
+    });
+
+    // Assert sweep result
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/${TributeToolsWebhookTxType.SWEEP}/${UUID_FIXTURE}`
+        )
+      ).json()
+    ).toEqual({
+      txStatus: 'success',
+      txHash:
+        '0x295cc18927e6cf72bf0103c9df4ec3507f76ea1a42721be38ee5cc8a0cd627da',
+    });
+
+    // Assert fund result
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/${TributeToolsWebhookTxType.FUND}/${UUID_FIXTURE}`
+        )
+      ).json()
+    ).toEqual({
+      txStatus: 'success',
+      txHash:
+        '0x70477c8ad25fc880f2ad49c09c4c04ca8e4a31082ae36214c80044e045f4f549',
+    });
+
+    // Cleanup
+
+    buyNFTPollSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('should return not found', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    /**
+     * Mock result
+     *
+     * @todo Fix types
+     */
+    const buyNFTPollSpy = (
+      prismaMock.buyNFTPoll as any
+    ).findUnique.mockResolvedValue(undefined);
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    // Assert result
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/${TributeToolsWebhookTxType.BUY}/${UUID_FIXTURE}`
+        )
+      ).json()
+    ).toEqual({
+      error: {
+        message: 'The transaction was not found.',
+        status: 404,
+      },
+    });
+
+    // Cleanup
+
+    buyNFTPollSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('should return bad request if params are not valid', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    /**
+     * Mock result
+     *
+     * @todo Fix types
+     */
+    const buyNFTPollSpy = (
+      prismaMock.buyNFTPoll as any
+    ).findUnique.mockResolvedValue({
+      error: {
+        message: 'The provided parameters are invalid.',
+        status: 400,
+      },
+    });
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/${TributeToolsWebhookTxType.BUY}/bad-uuid`
+        )
+      ).json()
+    ).toEqual({
+      error: {
+        message: 'The provided parameters are invalid.',
+        status: 400,
+      },
+    });
+
+    // Assert `:uuid` param invalid
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    expect(zodErrorHelper(consoleErrorSpy.mock.calls[0][0])).toEqual([
+      {
+        validation: 'uuid',
+        code: 'invalid_string',
+        message: 'Invalid uuid',
+        path: ['uuid'],
+      },
+    ]);
+
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/bad-type/${UUID_FIXTURE}`
+        )
+      ).json()
+    ).toEqual({
+      error: {
+        message: 'The provided parameters are invalid.',
+        status: 400,
+      },
+    });
+
+    // Assert `:type` param invalid
+    expect(zodErrorHelper(consoleErrorSpy.mock.calls[1][0])).toEqual([
+      {
+        code: 'invalid_enum_value',
+        message: "Invalid enum value. Expected 'singleBuy' | 'fund' | 'sweep'",
+        options: ['singleBuy', 'fund', 'sweep'],
+        path: ['type'],
+      },
+    ]);
+
+    // Assert log call count
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+
+    // Cleanup
+
+    buyNFTPollSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('should return server error', async () => {
+    const {port} = server?.address() as AddressInfo;
+
+    /**
+     * Mock result
+     *
+     * @todo Fix types
+     */
+    const buyNFTPollSpy = (
+      prismaMock.buyNFTPoll as any
+    ).findUnique.mockImplementation(() => {
+      throw new Error('Some bad error.');
+    });
+
+    // Temporarily hide warnings from `msw`
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    // Assert result
+    expect(
+      await (
+        await fetch(
+          `http://localhost:${port}${HTTP_API_BASE_PATH}/tribute-tools/tx/${TributeToolsWebhookTxType.BUY}/${UUID_FIXTURE}`
+        )
+      ).json()
+    ).toEqual({
+      error: {
+        message: `Something went wrong while getting the transaction data for type \`${TributeToolsWebhookTxType.BUY}\` uuid \`02458ff0-4cc5-4137-bcf5-ef91053ab811\`.`,
+        status: 500,
+      },
+    });
+
+    // Assert `console.error`
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+
+    expect(consoleErrorSpy.mock.calls[0][0]?.message).toMatch(
+      /some bad error/i
+    );
+
+    expect(consoleErrorSpy.mock.calls[1][0]).toMatch(
+      /HTTP API Error from \/api\/tribute-tools\/tx\/singleBuy\/02458ff0-4cc5-4137-bcf5-ef91053ab811 Error: Something went wrong while getting the transaction data for type \`singleBuy\` uuid `02458ff0-4cc5-4137-bcf5-ef91053ab811\`\./i
+    );
+
+    // Cleanup
+
+    buyNFTPollSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
 });

--- a/src/http-api/middleware/tributeTools/tributeToolsGetTx.unit.test.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsGetTx.unit.test.ts
@@ -101,6 +101,8 @@ describe('tributeToolsGetTx unit tests', () => {
     // Cleanup
 
     buyNFTPollSpy.mockRestore();
+    fundNFTPollSpy.mockRestore();
+    sweepNFTPollSpy.mockRestore();
     consoleWarnSpy.mockRestore();
   });
 

--- a/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.unit.test.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.unit.test.ts
@@ -2,11 +2,14 @@ import {AddressInfo} from 'node:net';
 import {Prisma} from '@prisma/client';
 import fetch from 'node-fetch';
 
-import {BYTES32_FIXTURE, UUID_FIXTURE} from '../../../test/fixtures';
-import {HTTP_API_BASE_PATH} from '../config';
-import {httpServer} from '../httpServer';
-import {prismaMock} from '../../../test/prismaMock';
-import {TributeToolsWebhookTxStatus, TributeToolsWebhookTxType} from '../types';
+import {
+  TributeToolsWebhookTxStatus,
+  TributeToolsWebhookTxType,
+} from '../../types';
+import {BYTES32_FIXTURE, UUID_FIXTURE} from '../../../../test/fixtures';
+import {HTTP_API_BASE_PATH} from '../../config';
+import {httpServer} from '../../httpServer';
+import {prismaMock} from '../../../../test/prismaMock';
 
 describe('tributeToolsTxWebhook unit tests', () => {
   const server = httpServer({noLog: true, useAnyAvailablePort: true});


### PR DESCRIPTION
Fixes #90 

🥳 **Adds**

- `GET .../tribute-tools/tx/<type>/<uuid>`
- `GET .../tribute-tools/tx/<daoName>/<type>`
- `@koa/router`, `@types/koa__router` packages

✨ **Updates**

- Handler registry was updated to accommodate `@koa/router` `Route`s
- `error` handler now returns JSON
