### PR TITLE
Display transaction status for `/buy`, `/sweep`, `/fund` polls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm run docker:teardown -- --rmi=all
 
 ### Applying new Prisma database migrations
 
-When running `npm start` any migrations will be run which have not yet been applied to the database, or which are yet to be created as a result of a `schema.prisma` change. Database migrations do not automatically run during active local development (i.e. via `nodemon` watching for file changes). You will need to follow the instructions under _Updating migrations after schema changes_.
+When running `npm start` any migrations will be run which have not yet been applied to the database, or which are yet to be created as a result of a `schema.prisma` change. Database migrations do not automatically run during active local development (i.e. via `nodemon` watching for file changes). You will need to follow the instructions under _Creating migrations after schema changes_.
 
 ### Creating migrations after schema changes
 

--- a/README.md
+++ b/README.md
@@ -41,15 +41,23 @@ npm run docker:teardown
 npm run docker:teardown -- --rmi=all
 ```
 
-### Updating Prisma database migrations
+### Applying new Prisma database migrations
 
-When running `npm start` any migrations will be run which have not yet been applied to the database, or which are yet to be created as a result of a `schema.prisma` change.
+When running `npm start` any migrations will be run which have not yet been applied to the database, or which are yet to be created as a result of a `schema.prisma` change. Database migrations do not automatically run during active local development (i.e. via `nodemon` watching for file changes). You will need to follow the instructions under _Updating migrations after schema changes_.
 
-#### Updating migrations after schema changes
+### Creating migrations after schema changes
 
-Make sure the Docker containers have started, or at least the `db` service, then create and/or run the migrations.
+Make sure the `db` container has started, then create and/or run the migrations.
 
 See [developing with Prisma `migrate`](https://www.prisma.io/docs/guides/database/developing-with-prisma-migrate) for more information.
+
+There is a convenient npm command for this below. The `DATABASE_URL` will most likely be needed. This is because when using `npm start` the database container name, `db`, is used instead of `localhost` due to Docker container networking. The `DATABASE_URL` environment variable can be found in `/.env.dev`.
+
+```sh
+DATABASE_URL="postgresql://postgres:<PASSWORD>@localhost:<HOST_POST>/postgres" npm run docker:migrate:dev
+```
+
+Alternatively, the `migrate:dev` npm command is also available. Any arguments passed should be for Prisma's `prisma migrate dev`:
 
 ```sh
 # Creates a new migration, applies it to the database, and updates the generated Prisma Client
@@ -81,3 +89,23 @@ Any push to `main` will run a development environment release to Tribute Labs' G
 It is recommended to use [`bump`](https://github.com/mroth/bump) locally to deploy a production release; the formatting is nice! Bump will determine the next semantic version and open a page to create a new GitHub release. The tag will be created once the GitHub release is published, not when `bump` is run.
 
 Any tags (`v*`) pushed to `main` will run a production environment release to Tribute Labs' Google Cloud->Kubernetes Engine. The `deploy-prod.yml` GitHub Action will run and, if successful, will push a commit to `infrastructure`, which will complete the deployment to Google Cloud.
+
+---
+
+⚠️ Warnings for the current datasource:
+
+• A unique constraint covering the columns `[actionMessageID]` on the table `buy_nft_poll` will be added. If there are existing duplicate values, this will fail.
+• A unique constraint covering the columns `[actionMessageID]` on the table `floor_sweeper_poll` will be added. If there are existing duplicate values, this will fail.
+• A unique constraint covering the columns `[actionMessageID]` on the table `fund_address_poll` will be added. If there are existing duplicate values, this will fail.
+
+✔ Are you sure you want create and apply this migration? … yes
+✔ Enter a name for the new migration: …
+Applying migration `20220303135522_`
+
+The following migration(s) have been created and applied from new schema changes:
+
+migrations/
+└─ 20220303135522\_/
+└─ migration.sql
+
+Your database is now in sync with your schema.

--- a/README.md
+++ b/README.md
@@ -89,23 +89,3 @@ Any push to `main` will run a development environment release to Tribute Labs' G
 It is recommended to use [`bump`](https://github.com/mroth/bump) locally to deploy a production release; the formatting is nice! Bump will determine the next semantic version and open a page to create a new GitHub release. The tag will be created once the GitHub release is published, not when `bump` is run.
 
 Any tags (`v*`) pushed to `main` will run a production environment release to Tribute Labs' Google Cloud->Kubernetes Engine. The `deploy-prod.yml` GitHub Action will run and, if successful, will push a commit to `infrastructure`, which will complete the deployment to Google Cloud.
-
----
-
-⚠️ Warnings for the current datasource:
-
-• A unique constraint covering the columns `[actionMessageID]` on the table `buy_nft_poll` will be added. If there are existing duplicate values, this will fail.
-• A unique constraint covering the columns `[actionMessageID]` on the table `floor_sweeper_poll` will be added. If there are existing duplicate values, this will fail.
-• A unique constraint covering the columns `[actionMessageID]` on the table `fund_address_poll` will be added. If there are existing duplicate values, this will fail.
-
-✔ Are you sure you want create and apply this migration? … yes
-✔ Enter a name for the new migration: …
-Applying migration `20220303135522_`
-
-The following migration(s) have been created and applied from new schema changes:
-
-migrations/
-└─ 20220303135522\_/
-└─ migration.sql
-
-Your database is now in sync with your schema.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "npm run generate-abi-types && npx prisma generate && npx tsc",
     "docker:down": "docker-compose -f docker-compose.dev.yml down --remove-orphans",
+    "docker:migrate:dev": "docker-compose -f docker-compose.dev.yml start db && npm run migrate:dev && docker-compose -f docker-compose.dev.yml stop db",
     "docker:teardown": "npm run docker:down -- -v",
     "docker:up": "docker-compose -f docker-compose.dev.yml up --build --remove-orphans",
     "generate-abi-types": "typechain --target=web3-v1 --out-dir='abi-types' 'src/abis/**/*.json'",

--- a/prisma/migrations/20220303135522_/migration.sql
+++ b/prisma/migrations/20220303135522_/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[actionMessageID]` on the table `buy_nft_poll` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[actionMessageID]` on the table `floor_sweeper_poll` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[actionMessageID]` on the table `fund_address_poll` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "buy_nft_poll" ADD COLUMN     "actionMessageID" VARCHAR(255);
+
+-- AlterTable
+ALTER TABLE "floor_sweeper_poll" ADD COLUMN     "actionMessageID" VARCHAR(255);
+
+-- AlterTable
+ALTER TABLE "fund_address_poll" ADD COLUMN     "actionMessageID" VARCHAR(255);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "buy_nft_poll_actionMessageID_key" ON "buy_nft_poll"("actionMessageID");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "floor_sweeper_poll_actionMessageID_key" ON "floor_sweeper_poll"("actionMessageID");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "fund_address_poll_actionMessageID_key" ON "fund_address_poll"("actionMessageID");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model FloorSweeperPoll {
   guildID         String                @db.VarChar(255)
   channelID       String                @db.VarChar(255)
   messageID       String                @unique @db.VarChar(255)
+  actionMessageID String?               @unique @db.VarChar(255)
   txStatus        TributeToolsTxStatus?
   txHash          String?               @db.VarChar(255)
 
@@ -62,6 +63,7 @@ model BuyNFTPoll {
   guildID         String                @db.VarChar(255)
   channelID       String                @db.VarChar(255)
   messageID       String                @unique @db.VarChar(255)
+  actionMessageID String?               @unique @db.VarChar(255)
   txStatus        TributeToolsTxStatus?
   txHash          String?               @db.VarChar(255)
 
@@ -69,20 +71,21 @@ model BuyNFTPoll {
 }
 
 model FundAddressPoll {
-  id            Int                   @id @default(autoincrement())
-  uuid          String                @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  createdAt     DateTime              @default(now())
-  purpose       String                @db.VarChar(255)
-  addressToFund String                @db.VarChar(255)
-  amountUSDC    Int                   @default(0) @db.Integer
-  processed     Boolean               @default(false) @db.Boolean
-  voteThreshold Int                   @default(0) @db.Integer
-  upvoteCount   Int                   @default(0) @db.Integer
-  guildID       String                @db.VarChar(255)
-  channelID     String                @db.VarChar(255)
-  messageID     String                @unique @db.VarChar(255)
-  txStatus      TributeToolsTxStatus?
-  txHash        String?               @db.VarChar(255)
+  id              Int                   @id @default(autoincrement())
+  uuid            String                @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  createdAt       DateTime              @default(now())
+  purpose         String                @db.VarChar(255)
+  addressToFund   String                @db.VarChar(255)
+  amountUSDC      Int                   @default(0) @db.Integer
+  processed       Boolean               @default(false) @db.Boolean
+  voteThreshold   Int                   @default(0) @db.Integer
+  upvoteCount     Int                   @default(0) @db.Integer
+  guildID         String                @db.VarChar(255)
+  channelID       String                @db.VarChar(255)
+  messageID       String                @unique @db.VarChar(255)
+  actionMessageID String?               @unique @db.VarChar(255)
+  txStatus        TributeToolsTxStatus?
+  txHash          String?               @db.VarChar(255)
 
   @@map("fund_address_poll")
 }

--- a/src/applications/tribute-tools/getTributeToolsClient.ts
+++ b/src/applications/tribute-tools/getTributeToolsClient.ts
@@ -1,0 +1,54 @@
+import {Client, Intents} from 'discord.js';
+
+import {destroyClientHandler} from '../helpers';
+import {getEnv} from '../../helpers';
+
+let clientCached: Client | undefined;
+
+function clientStop(client: Client): () => Promise<void> {
+  return async () => {
+    await destroyClientHandler(client, 'TRIBUTE_TOOLS_BOT');
+
+    // invalidate cache
+    clientCached = undefined;
+  };
+}
+
+export async function getTributeToolsClient(): Promise<{
+  client: Client;
+  stop: () => Promise<void>;
+}> {
+  try {
+    if (clientCached) {
+      return {
+        client: clientCached,
+        stop: clientStop(clientCached),
+      };
+    }
+
+    // Create a new Discord client instance
+    const client = new Client({
+      intents: [
+        Intents.FLAGS.GUILDS,
+        Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+      ],
+      partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
+    });
+
+    // Login to Discord with the bot's token
+    await client.login(getEnv('BOT_TOKEN_TRIBUTE_TOOLS'));
+
+    // Set cache
+    clientCached = client;
+
+    return {
+      client: client,
+      stop: clientStop(client),
+    };
+  } catch (error) {
+    console.error(error);
+
+    throw error;
+  }
+}

--- a/src/applications/tribute-tools/getTributeToolsClient.unit.test.ts
+++ b/src/applications/tribute-tools/getTributeToolsClient.unit.test.ts
@@ -1,0 +1,79 @@
+import {Client} from 'discord.js';
+
+import {getTributeToolsClient} from '.';
+
+describe('getTributeToolsClient unit tests', () => {
+  test('should return Discord `Client`', async () => {
+    const discord = await import('discord.js');
+
+    const loginSpy = jest
+      .spyOn(discord.Client.prototype, 'login')
+      .mockImplementation(async () => '');
+
+    const {client, stop} = await getTributeToolsClient();
+
+    expect(client).toBeInstanceOf(Client);
+    expect(stop).toBeInstanceOf(Function);
+    expect(loginSpy).toHaveBeenCalledTimes(1);
+
+    // Cleanup
+
+    loginSpy.mockRestore();
+    await stop();
+  });
+
+  test('should return cached Discord `Client`', async () => {
+    const discord = await import('discord.js');
+
+    const loginSpy = jest
+      .spyOn(discord.Client.prototype, 'login')
+      .mockImplementation(async () => '');
+
+    const {client, stop} = await getTributeToolsClient();
+
+    expect(client).toBeInstanceOf(Client);
+    expect(stop).toBeInstanceOf(Function);
+
+    const clientCached = await getTributeToolsClient();
+
+    expect(clientCached.client).toBeInstanceOf(Client);
+    expect(clientCached.stop).toBeInstanceOf(Function);
+
+    // Should not have been called twice, as the cached `Client` should have been returned.
+    expect(loginSpy).toHaveBeenCalledTimes(1);
+
+    // Cleanup
+
+    loginSpy.mockRestore();
+    await stop();
+  });
+
+  test('should handle error', async () => {
+    const discord = await import('discord.js');
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const loginSpy = jest
+      .spyOn(discord.Client.prototype, 'login')
+      .mockImplementation(async () => {
+        throw new Error('Some bad error');
+      });
+
+    try {
+      await getTributeToolsClient();
+    } catch (error) {
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+      expect(consoleErrorSpy.mock.calls[0][0]?.message).toMatch(
+        /some bad error/i
+      );
+    }
+
+    // Cleanup
+
+    loginSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.ts
+++ b/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.ts
@@ -228,6 +228,21 @@ export async function buyPollReactionHandler({
         await message.reply({
           embeds: [pollEndEmbed],
         });
+
+        /**
+         * Store result channel message ID in database.
+         *
+         * Placing at end in case of failure, the rest of the flow will work.
+         * This message ID is needed for later to report transaction status to the result channel.
+         */
+        await prisma.buyNFTPoll.update({
+          where: {
+            messageID: reaction.message.id,
+          },
+          data: {
+            actionMessageID: buyChannelMessage.id,
+          },
+        });
       }
     }
   } catch (error) {

--- a/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.unit.test.ts
@@ -85,7 +85,7 @@ describe('buyPollReactionHandler unit tests', () => {
   test('should handle poll threshold reached', async () => {
     const channelSendSpy = jest
       .fn()
-      .mockImplementation(async () => ({url: BUY_EXTERNAL_URL}));
+      .mockImplementation(async () => ({id: 'xyz456', url: BUY_EXTERNAL_URL}));
 
     const messageReplySpy = jest.fn();
 
@@ -168,7 +168,7 @@ describe('buyPollReactionHandler unit tests', () => {
 
     expect(dbFindSpy).toHaveBeenCalledTimes(1);
     expect(dbFindSpy).toHaveBeenCalledWith({where: {messageID: 'abc123'}});
-    expect(dbUpdateSpy).toHaveBeenCalledTimes(2);
+    expect(dbUpdateSpy).toHaveBeenCalledTimes(3);
 
     expect(dbUpdateSpy.mock.calls[0][0]).toEqual({
       data: {upvoteCount: 5},
@@ -177,6 +177,11 @@ describe('buyPollReactionHandler unit tests', () => {
 
     expect(dbUpdateSpy.mock.calls[1][0]).toEqual({
       data: {processed: true},
+      where: {messageID: 'abc123'},
+    });
+
+    expect(dbUpdateSpy.mock.calls[2][0]).toEqual({
+      data: {actionMessageID: 'xyz456'},
       where: {messageID: 'abc123'},
     });
 

--- a/src/applications/tribute-tools/handlers/fund/fundPollReactionHandler.ts
+++ b/src/applications/tribute-tools/handlers/fund/fundPollReactionHandler.ts
@@ -226,6 +226,21 @@ export async function fundPollReactionHandler({
         await message.reply({
           embeds: [pollEndEmbed],
         });
+
+        /**
+         * Store result channel message ID in database.
+         *
+         * Placing at end in case of failure, the rest of the flow will work.
+         * This message ID is needed for later to report transaction status to the result channel.
+         */
+        await prisma.fundAddressPoll.update({
+          where: {
+            messageID: reaction.message.id,
+          },
+          data: {
+            actionMessageID: fundChannelMessage.id,
+          },
+        });
       }
     }
   } catch (error) {

--- a/src/applications/tribute-tools/handlers/fund/fundPollReactionHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/fund/fundPollReactionHandler.unit.test.ts
@@ -85,7 +85,7 @@ describe('fundPollReactionHandler unit tests', () => {
   test('should handle poll threshold reached', async () => {
     const channelSendSpy = jest
       .fn()
-      .mockImplementation(async () => ({url: FUND_EXTERNAL_URL}));
+      .mockImplementation(async () => ({id: 'xyz456', url: FUND_EXTERNAL_URL}));
 
     const messageReplySpy = jest.fn();
 
@@ -168,7 +168,7 @@ describe('fundPollReactionHandler unit tests', () => {
 
     expect(dbFindSpy).toHaveBeenCalledTimes(1);
     expect(dbFindSpy).toHaveBeenCalledWith({where: {messageID: 'abc123'}});
-    expect(dbUpdateSpy).toHaveBeenCalledTimes(2);
+    expect(dbUpdateSpy).toHaveBeenCalledTimes(3);
 
     expect(dbUpdateSpy.mock.calls[0][0]).toEqual({
       data: {upvoteCount: 3},
@@ -177,6 +177,11 @@ describe('fundPollReactionHandler unit tests', () => {
 
     expect(dbUpdateSpy.mock.calls[1][0]).toEqual({
       data: {processed: true},
+      where: {messageID: 'abc123'},
+    });
+
+    expect(dbUpdateSpy.mock.calls[2][0]).toEqual({
+      data: {actionMessageID: 'xyz456'},
       where: {messageID: 'abc123'},
     });
 

--- a/src/applications/tribute-tools/handlers/index.ts
+++ b/src/applications/tribute-tools/handlers/index.ts
@@ -1,5 +1,5 @@
 export * from './buy';
 export * from './interactionExecuteHandler';
 export * from './fund';
-export * from './setPollTxStatus';
+export * from './notifyPollTxStatus';
 export * from './sweep';

--- a/src/applications/tribute-tools/handlers/index.ts
+++ b/src/applications/tribute-tools/handlers/index.ts
@@ -1,4 +1,5 @@
 export * from './buy';
 export * from './interactionExecuteHandler';
 export * from './fund';
+export * from './setPollTxStatus';
 export * from './sweep';

--- a/src/applications/tribute-tools/handlers/notifyPollTxStatus.ts
+++ b/src/applications/tribute-tools/handlers/notifyPollTxStatus.ts
@@ -64,7 +64,7 @@ function getStatus({
   }
 }
 
-export async function setPollTxStatus({
+export async function notifyPollTxStatus({
   client,
   dbEntry,
   payload,
@@ -74,6 +74,7 @@ export async function setPollTxStatus({
   payload: TributeToolsWebhookPayload;
 }): Promise<void> {
   const {channelID, messageID, txHash} = dbEntry;
+
   const {
     data: {
       tx: {status},

--- a/src/applications/tribute-tools/handlers/notifyPollTxStatus.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/notifyPollTxStatus.unit.test.ts
@@ -1,0 +1,335 @@
+import {
+  BuyNFTPoll,
+  FloorSweeperPoll,
+  FundAddressPoll,
+  TributeToolsTxStatus,
+} from '@prisma/client';
+import {Client, Intents, MessageEmbed} from 'discord.js';
+
+import {
+  TributeToolsWebhookTxStatus,
+  TributeToolsWebhookTxType,
+} from '../../../http-api/types';
+import {
+  BYTES32_FIXTURE,
+  ETH_ADDRESS_FIXTURE,
+  GUILD_ID_FIXTURE,
+  UUID_FIXTURE,
+} from '../../../../test/fixtures';
+import {notifyPollTxStatus} from './notifyPollTxStatus';
+
+describe('notifyPollTxStatus unit tests', () => {
+  const SWEEP_DB_ENTRY: FloorSweeperPoll = {
+    id: 1,
+    uuid: UUID_FIXTURE,
+    createdAt: new Date(0),
+    question: 'How much in punks should we sweep?',
+    contractAddress: ETH_ADDRESS_FIXTURE,
+    dateEnd: new Date(10000),
+    options: {'🇦': 50, '🇧': 100, '🇨': 150, '🚫': 'None'},
+    processed: true,
+    result: 100,
+    guildID: GUILD_ID_FIXTURE,
+    channelID: '123456789',
+    messageID: '567890123',
+    actionMessageID: '987654321',
+    txStatus: TributeToolsTxStatus.success,
+    txHash: BYTES32_FIXTURE,
+  };
+
+  const BUY_DB_ENTRY: BuyNFTPoll = {
+    actionMessageID: '987654321',
+    channelID: '123456789',
+    contractAddress: ETH_ADDRESS_FIXTURE,
+    createdAt: new Date(0),
+    guildID: GUILD_ID_FIXTURE,
+    id: 1,
+    messageID: '567890123',
+    name: 'Should we buy Dexter Funky Xavier?',
+    processed: true,
+    tokenID: '123',
+    txHash: BYTES32_FIXTURE,
+    txStatus: TributeToolsTxStatus.success,
+    upvoteCount: 5,
+    uuid: UUID_FIXTURE,
+    voteThreshold: 5,
+  };
+
+  const FUND_DB_ENTRY: FundAddressPoll = {
+    actionMessageID: '987654321',
+    addressToFund: ETH_ADDRESS_FIXTURE,
+    amountUSDC: 123,
+    channelID: '123456789',
+    createdAt: new Date(0),
+    guildID: GUILD_ID_FIXTURE,
+    id: 1,
+    messageID: '567890123',
+    processed: true,
+    purpose: 'Seed round for Tribute Labs',
+    txHash: BYTES32_FIXTURE,
+    txStatus: TributeToolsTxStatus.success,
+    upvoteCount: 5,
+    uuid: UUID_FIXTURE,
+    voteThreshold: 5,
+  };
+
+  test('should notify Discord when a successful transaction is sent', async () => {
+    const client = new Client({
+      intents: [
+        Intents.FLAGS.GUILDS,
+        Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+      ],
+      partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
+    });
+
+    // `Client` needs a token to make a REST call
+    client.token = 'abc123';
+
+    const messagesReplySpy = jest.fn();
+
+    const messagesFetchSpy = jest.fn().mockImplementation(() => ({
+      reply: messagesReplySpy,
+    }));
+
+    const channelsFetchSpy = jest
+      .spyOn(client.channels, 'fetch')
+      .mockImplementation(
+        () =>
+          ({
+            messages: {
+              fetch: messagesFetchSpy,
+            },
+          } as any)
+      );
+
+    const result = await notifyPollTxStatus({
+      client,
+      dbEntry: SWEEP_DB_ENTRY,
+      payload: {
+        data: {
+          id: UUID_FIXTURE,
+          type: TributeToolsWebhookTxType.SWEEP,
+          tx: {
+            hash: BYTES32_FIXTURE,
+            status: TributeToolsWebhookTxStatus.SUCCESS,
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(undefined);
+    expect(channelsFetchSpy).toHaveBeenCalledTimes(1);
+    expect(messagesFetchSpy).toHaveBeenCalledTimes(1);
+    expect(messagesReplySpy).toHaveBeenCalledTimes(1);
+
+    expect(channelsFetchSpy).toHaveBeenNthCalledWith(1, '123456789');
+    expect(messagesFetchSpy).toHaveBeenNthCalledWith(1, '567890123');
+
+    expect(messagesReplySpy).toHaveBeenNthCalledWith(1, {
+      embeds: [
+        new MessageEmbed()
+          .setTitle('Sweep')
+          .setURL(`https://etherscan.io/tx/${BYTES32_FIXTURE}`)
+          .setDescription(
+            '✅ Transaction succeeded for *How much in punks should we sweep?*.'
+          ),
+      ],
+    });
+  });
+
+  test('should notify Discord when a failed transaction is sent', async () => {
+    const client = new Client({
+      intents: [
+        Intents.FLAGS.GUILDS,
+        Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+      ],
+      partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
+    });
+
+    // `Client` needs a token to make a REST call
+    client.token = 'abc123';
+
+    const messagesReplySpy = jest.fn();
+
+    const messagesFetchSpy = jest.fn().mockImplementation(() => ({
+      reply: messagesReplySpy,
+    }));
+
+    const channelsFetchSpy = jest
+      .spyOn(client.channels, 'fetch')
+      .mockImplementation(
+        () =>
+          ({
+            messages: {
+              fetch: messagesFetchSpy,
+            },
+          } as any)
+      );
+
+    const result = await notifyPollTxStatus({
+      client,
+      dbEntry: SWEEP_DB_ENTRY,
+      payload: {
+        data: {
+          id: UUID_FIXTURE,
+          type: TributeToolsWebhookTxType.SWEEP,
+          tx: {
+            hash: BYTES32_FIXTURE,
+            status: TributeToolsWebhookTxStatus.FAILED,
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(undefined);
+    expect(channelsFetchSpy).toHaveBeenCalledTimes(1);
+    expect(messagesFetchSpy).toHaveBeenCalledTimes(1);
+    expect(messagesReplySpy).toHaveBeenCalledTimes(1);
+
+    expect(channelsFetchSpy).toHaveBeenNthCalledWith(1, '123456789');
+    expect(messagesFetchSpy).toHaveBeenNthCalledWith(1, '567890123');
+
+    expect(messagesReplySpy).toHaveBeenNthCalledWith(1, {
+      embeds: [
+        new MessageEmbed()
+          .setTitle('Sweep')
+          .setURL(`https://etherscan.io/tx/${BYTES32_FIXTURE}`)
+          .setDescription(
+            '❌ Transaction failed for *How much in punks should we sweep?*.'
+          ),
+      ],
+    });
+  });
+
+  test('should notify Discord when a `/buy` transaction is sent', async () => {
+    const client = new Client({
+      intents: [
+        Intents.FLAGS.GUILDS,
+        Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+      ],
+      partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
+    });
+
+    // `Client` needs a token to make a REST call
+    client.token = 'abc123';
+
+    const messagesReplySpy = jest.fn();
+
+    const messagesFetchSpy = jest.fn().mockImplementation(() => ({
+      reply: messagesReplySpy,
+    }));
+
+    const channelsFetchSpy = jest
+      .spyOn(client.channels, 'fetch')
+      .mockImplementation(
+        () =>
+          ({
+            messages: {
+              fetch: messagesFetchSpy,
+            },
+          } as any)
+      );
+
+    const result = await notifyPollTxStatus({
+      client,
+      dbEntry: BUY_DB_ENTRY,
+      payload: {
+        data: {
+          id: UUID_FIXTURE,
+          type: TributeToolsWebhookTxType.BUY,
+          tx: {
+            hash: BYTES32_FIXTURE,
+            status: TributeToolsWebhookTxStatus.SUCCESS,
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(undefined);
+    expect(channelsFetchSpy).toHaveBeenCalledTimes(1);
+    expect(messagesFetchSpy).toHaveBeenCalledTimes(1);
+    expect(messagesReplySpy).toHaveBeenCalledTimes(1);
+
+    expect(channelsFetchSpy).toHaveBeenNthCalledWith(1, '123456789');
+    expect(messagesFetchSpy).toHaveBeenNthCalledWith(1, '567890123');
+
+    expect(messagesReplySpy).toHaveBeenNthCalledWith(1, {
+      embeds: [
+        new MessageEmbed()
+          .setTitle('Buy')
+          .setURL(`https://etherscan.io/tx/${BYTES32_FIXTURE}`)
+          .setDescription(
+            '✅ Transaction succeeded for *Should we buy Dexter Funky Xavier?*.'
+          ),
+      ],
+    });
+  });
+
+  test('should notify Discord when a `/fund` transaction is sent', async () => {
+    const client = new Client({
+      intents: [
+        Intents.FLAGS.GUILDS,
+        Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+      ],
+      partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
+    });
+
+    // `Client` needs a token to make a REST call
+    client.token = 'abc123';
+
+    const messagesReplySpy = jest.fn();
+
+    const messagesFetchSpy = jest.fn().mockImplementation(() => ({
+      reply: messagesReplySpy,
+    }));
+
+    const channelsFetchSpy = jest
+      .spyOn(client.channels, 'fetch')
+      .mockImplementation(
+        () =>
+          ({
+            messages: {
+              fetch: messagesFetchSpy,
+            },
+          } as any)
+      );
+
+    const result = await notifyPollTxStatus({
+      client,
+      dbEntry: FUND_DB_ENTRY,
+      payload: {
+        data: {
+          id: UUID_FIXTURE,
+          type: TributeToolsWebhookTxType.FUND,
+          tx: {
+            hash: BYTES32_FIXTURE,
+            status: TributeToolsWebhookTxStatus.SUCCESS,
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(undefined);
+    expect(channelsFetchSpy).toHaveBeenCalledTimes(1);
+    expect(messagesFetchSpy).toHaveBeenCalledTimes(1);
+    expect(messagesReplySpy).toHaveBeenCalledTimes(1);
+
+    expect(channelsFetchSpy).toHaveBeenNthCalledWith(1, '123456789');
+    expect(messagesFetchSpy).toHaveBeenNthCalledWith(1, '567890123');
+
+    expect(messagesReplySpy).toHaveBeenNthCalledWith(1, {
+      embeds: [
+        new MessageEmbed()
+          .setTitle('Fund')
+          .setURL(`https://etherscan.io/tx/${BYTES32_FIXTURE}`)
+          .setDescription(
+            '✅ Transaction succeeded for *Seed round for Tribute Labs*.'
+          ),
+      ],
+    });
+  });
+});

--- a/src/applications/tribute-tools/handlers/setPollTxStatus.ts
+++ b/src/applications/tribute-tools/handlers/setPollTxStatus.ts
@@ -1,0 +1,118 @@
+import {Client, MessageEmbed, TextChannel} from 'discord.js';
+import {
+  BuyNFTPoll,
+  FloorSweeperPoll,
+  FundAddressPoll,
+  TributeToolsTxStatus,
+} from '@prisma/client';
+
+import {
+  TributeToolsWebhookPayload,
+  TributeToolsWebhookTxStatus,
+  TributeToolsWebhookTxType,
+} from '../../../http-api/types';
+
+type SetPollTxStatusParams = {
+  channelID: string;
+  client: Client;
+  messageID: string;
+  txHash: string;
+  txStatus: TributeToolsWebhookTxStatus;
+  type: TributeToolsWebhookTxType;
+};
+
+function getTitle(type: TributeToolsWebhookTxType): 'Buy' | 'Sweep' | 'Fund' {
+  switch (type) {
+    case TributeToolsWebhookTxType.BUY:
+      return 'Buy';
+
+    case TributeToolsWebhookTxType.FUND:
+      return 'Fund';
+
+    case TributeToolsWebhookTxType.SWEEP:
+      return 'Sweep';
+
+    default:
+      throw new Error(`\`type\` ${type} was not found.`);
+  }
+}
+
+function getName({
+  dbEntry,
+  type,
+}: {
+  dbEntry: FloorSweeperPoll | FundAddressPoll | BuyNFTPoll;
+  type: TributeToolsWebhookTxType;
+}): string {
+  switch (type) {
+    case TributeToolsWebhookTxType.BUY:
+      return (dbEntry as BuyNFTPoll).name;
+
+    case TributeToolsWebhookTxType.FUND:
+      return (dbEntry as FundAddressPoll).purpose;
+
+    case TributeToolsWebhookTxType.SWEEP:
+      return (dbEntry as FloorSweeperPoll).question;
+
+    default:
+      throw new Error(`\`type\` ${type} was not found.`);
+  }
+}
+
+function getStatus({
+  name,
+  status,
+}: {
+  name: string;
+  status: TributeToolsWebhookTxStatus;
+}): string {
+  switch (status) {
+    case TributeToolsWebhookTxStatus.SUCCESS:
+      return `✅ Transaction succeeded for *${name}*.`;
+
+    case TributeToolsWebhookTxStatus.FAILED:
+      return `❌ Transaction failed for *${name}*.`;
+
+    default:
+      throw new Error(`\`status\` ${status} was not found.`);
+  }
+}
+
+export async function setPollTxStatus({
+  client,
+  dbEntry,
+  payload,
+}: {
+  client: Client;
+  dbEntry: FloorSweeperPoll | FundAddressPoll | BuyNFTPoll;
+  payload: TributeToolsWebhookPayload;
+}): Promise<void> {
+  const {channelID, messageID, txHash, txStatus} = dbEntry;
+  const {
+    data: {
+      tx: {status},
+      type,
+    },
+  } = payload;
+
+  try {
+    const channel = (await client.channels.fetch(channelID)) as TextChannel;
+    const message = await channel.messages.fetch(messageID);
+
+    const title = getTitle(type);
+    const name = getName({dbEntry, type});
+    const description = getStatus({name, status});
+
+    const pollStatusEmbed = new MessageEmbed()
+      .setTitle(title)
+      .setURL(`https://etherscan.io/tx/${txHash}`)
+      .setDescription(description);
+
+    // Notify poll channel of the related tx's status
+    await message.reply({
+      embeds: [pollStatusEmbed],
+    });
+  } catch (error) {
+    throw error;
+  }
+}

--- a/src/applications/tribute-tools/handlers/setPollTxStatus.ts
+++ b/src/applications/tribute-tools/handlers/setPollTxStatus.ts
@@ -1,25 +1,11 @@
+import {BuyNFTPoll, FloorSweeperPoll, FundAddressPoll} from '@prisma/client';
 import {Client, MessageEmbed, TextChannel} from 'discord.js';
-import {
-  BuyNFTPoll,
-  FloorSweeperPoll,
-  FundAddressPoll,
-  TributeToolsTxStatus,
-} from '@prisma/client';
 
 import {
   TributeToolsWebhookPayload,
   TributeToolsWebhookTxStatus,
   TributeToolsWebhookTxType,
 } from '../../../http-api/types';
-
-type SetPollTxStatusParams = {
-  channelID: string;
-  client: Client;
-  messageID: string;
-  txHash: string;
-  txStatus: TributeToolsWebhookTxStatus;
-  type: TributeToolsWebhookTxType;
-};
 
 function getTitle(type: TributeToolsWebhookTxType): 'Buy' | 'Sweep' | 'Fund' {
   switch (type) {
@@ -87,7 +73,7 @@ export async function setPollTxStatus({
   dbEntry: FloorSweeperPoll | FundAddressPoll | BuyNFTPoll;
   payload: TributeToolsWebhookPayload;
 }): Promise<void> {
-  const {channelID, messageID, txHash, txStatus} = dbEntry;
+  const {channelID, messageID, txHash} = dbEntry;
   const {
     data: {
       tx: {status},

--- a/src/applications/tribute-tools/handlers/sweep/sweepEndedPollsHandler.ts
+++ b/src/applications/tribute-tools/handlers/sweep/sweepEndedPollsHandler.ts
@@ -181,6 +181,21 @@ export function sweepEndedPollsHandler({
           await message.reply({
             embeds: [pollEndEmbed],
           });
+
+          /**
+           * Store result channel message ID in database.
+           *
+           * Placing at end in case of failure, the rest of the flow will work.
+           * This message ID is needed for later to report transaction status to the result channel.
+           */
+          await prisma.floorSweeperPoll.update({
+            where: {
+              id,
+            },
+            data: {
+              actionMessageID: sweepChannelMessage?.id,
+            },
+          });
         } catch (error) {
           console.error(
             `There was an error while processing an ended poll: ${error}`

--- a/src/applications/tribute-tools/handlers/sweep/sweepEndedPollsHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/sweep/sweepEndedPollsHandler.unit.test.ts
@@ -56,6 +56,15 @@ describe('sweepEndedPollsHandler unit tests', () => {
       prismaMock.floorSweeperPoll as any
     ).findMany.mockResolvedValue([DB_ENTRY, DB_ENTRY_1]);
 
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateSpy = (
+      prismaMock.floorSweeperPoll as any
+    ).update.mockImplementation(async () => {});
+
     // Mock `getDaos`
     const getDaosSpy = jest
       .spyOn(await import('../../../../services/dao/getDaos'), 'getDaos')
@@ -73,9 +82,6 @@ describe('sweepEndedPollsHandler unit tests', () => {
     // `Client` needs a token to make a REST call
     client.token = 'abc123';
 
-    // Mock `setInterval`
-    // const setIntervalSpy = jest.spyOn(global, 'setInterval');
-
     const messagesReplySpy = jest.fn();
 
     const messagesFetchSpy = jest.fn().mockImplementation(() => ({
@@ -91,6 +97,7 @@ describe('sweepEndedPollsHandler unit tests', () => {
     }));
 
     const messagesSendSpy = jest.fn().mockImplementation(() => ({
+      id: 'xyz456',
       url: 'https://discord.com/some/message/url',
     }));
 
@@ -229,6 +236,58 @@ describe('sweepEndedPollsHandler unit tests', () => {
     expect(messagesReplySpy.mock.calls[1][0].embeds[0]).toBeInstanceOf(
       MessageEmbed
     );
+
+    // Assert DB update
+
+    expect(dbUpdateSpy).toHaveBeenCalledTimes(8);
+
+    // Call 1
+    expect(dbUpdateSpy).toHaveBeenNthCalledWith(1, {
+      data: {processed: true, result: 100},
+      where: {id: 1},
+    });
+
+    // Call 2
+    expect(dbUpdateSpy).toHaveBeenNthCalledWith(2, {
+      data: {processed: true, result: 200},
+      where: {id: 2},
+    });
+
+    // Call 3
+    expect(dbUpdateSpy).toHaveBeenNthCalledWith(3, {
+      data: {processed: true, result: 100},
+      where: {id: 1},
+    });
+
+    // Call 4
+    expect(dbUpdateSpy).toHaveBeenNthCalledWith(4, {
+      data: {processed: true, result: 200},
+      where: {id: 2},
+    });
+
+    // Call 5
+    expect(dbUpdateSpy).toHaveBeenNthCalledWith(5, {
+      data: {actionMessageID: 'xyz456'},
+      where: {id: 1},
+    });
+
+    // Call 6
+    expect(dbUpdateSpy).toHaveBeenNthCalledWith(6, {
+      data: {actionMessageID: 'xyz456'},
+      where: {id: 2},
+    });
+
+    // Call 7
+    expect(dbUpdateSpy).toHaveBeenNthCalledWith(7, {
+      data: {actionMessageID: 'xyz456'},
+      where: {id: 1},
+    });
+
+    // Call 8
+    expect(dbUpdateSpy).toHaveBeenNthCalledWith(8, {
+      data: {actionMessageID: 'xyz456'},
+      where: {id: 2},
+    });
 
     // Cleanup
 

--- a/src/applications/tribute-tools/index.ts
+++ b/src/applications/tribute-tools/index.ts
@@ -1,2 +1,3 @@
 export * from './getTributeToolsClient';
+export * from './handlers/setPollTxStatus';
 export * from './main';

--- a/src/applications/tribute-tools/index.ts
+++ b/src/applications/tribute-tools/index.ts
@@ -1,3 +1,3 @@
 export * from './getTributeToolsClient';
-export * from './handlers/setPollTxStatus';
+export * from './handlers/notifyPollTxStatus';
 export * from './main';

--- a/src/applications/tribute-tools/index.ts
+++ b/src/applications/tribute-tools/index.ts
@@ -1,1 +1,2 @@
+export * from './getTributeToolsClient';
 export * from './main';

--- a/src/applications/tribute-tools/main.ts
+++ b/src/applications/tribute-tools/main.ts
@@ -70,10 +70,6 @@ export async function tributeToolsBot(): Promise<
       buyPollRemoveReactionHandler({reaction, user});
     });
 
-    // const stop = async (): Promise<void> => {
-    //   await destroyClientHandler(client, 'TRIBUTE_TOOLS_BOT');
-    // };
-
     return {
       client,
       name: 'TRIBUTE_TOOLS_BOT',

--- a/src/applications/tribute-tools/main.ts
+++ b/src/applications/tribute-tools/main.ts
@@ -1,5 +1,3 @@
-import {Client, Intents} from 'discord.js';
-
 import {
   sweepEndedPollsHandler,
   sweepPollReactionHandler,
@@ -14,6 +12,7 @@ import {
 import {ApplicationReturn} from '../types';
 import {deployCommands, destroyClientHandler, getCommands} from '../helpers';
 import {getEnv} from '../../helpers';
+import {getTributeToolsClient} from '.';
 import {TRIBUTE_TOOLS_BOT_ID} from '../../config';
 
 export async function tributeToolsBot(): Promise<
@@ -42,18 +41,8 @@ export async function tributeToolsBot(): Promise<
       return;
     }
 
-    // Create a new Discord client instance
-    const client = new Client({
-      intents: [
-        Intents.FLAGS.GUILDS,
-        Intents.FLAGS.GUILD_MESSAGES,
-        Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
-      ],
-      partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
-    });
-
-    // Login to Discord with the bot's token
-    client.login(getEnv('BOT_TOKEN_TRIBUTE_TOOLS'));
+    // Get client and log in
+    const {client, stop} = await getTributeToolsClient();
 
     // When the Discord client is ready, run this code (only once)
     client.once('ready', (): void => {
@@ -81,9 +70,9 @@ export async function tributeToolsBot(): Promise<
       buyPollRemoveReactionHandler({reaction, user});
     });
 
-    const stop = async (): Promise<void> => {
-      await destroyClientHandler(client, 'TRIBUTE_TOOLS_BOT');
-    };
+    // const stop = async (): Promise<void> => {
+    //   await destroyClientHandler(client, 'TRIBUTE_TOOLS_BOT');
+    // };
 
     return {
       client,

--- a/src/applications/tribute-tools/main.unit.test.ts
+++ b/src/applications/tribute-tools/main.unit.test.ts
@@ -40,6 +40,7 @@ describe('tribute-tools/main unit tests', () => {
 
     loginSpy.mockRestore();
     deployCommandsSpy.mockRestore();
+    await returnValue?.stop?.();
   });
 
   test('should call `ready` handlers', async () => {
@@ -80,6 +81,7 @@ describe('tribute-tools/main unit tests', () => {
     deployCommandsSpy.mockRestore();
     endedPollsHandlerSpy.mockRestore();
     loginSpy.mockRestore();
+    await returnValue?.stop?.();
   });
 
   test('should call `interactionCreate` handlers', async () => {
@@ -124,6 +126,7 @@ describe('tribute-tools/main unit tests', () => {
     deployCommandsSpy.mockRestore();
     interactionExecuteHandlerSpy.mockRestore();
     loginSpy.mockRestore();
+    await returnValue?.stop?.();
   });
 
   test('should call `messageReactionAdd` handlers', async () => {
@@ -136,6 +139,9 @@ describe('tribute-tools/main unit tests', () => {
     const buyPollReactionHandler = await import(
       './handlers/buy/buyPollReactionHandler'
     );
+    const fundPollReactionHandler = await import(
+      './handlers/fund/fundPollReactionHandler'
+    );
 
     const loginSpy = jest
       .spyOn(discord.Client.prototype, 'login')
@@ -147,6 +153,10 @@ describe('tribute-tools/main unit tests', () => {
 
     const buyPollReactionHandlerSpy = jest
       .spyOn(buyPollReactionHandler, 'buyPollReactionHandler')
+      .mockImplementation(() => null as any);
+
+    const fundPollReactionHandlerSpy = jest
+      .spyOn(fundPollReactionHandler, 'fundPollReactionHandler')
       .mockImplementation(() => null as any);
 
     const {tributeToolsBot} = await import('../tribute-tools/main');
@@ -184,8 +194,65 @@ describe('tribute-tools/main unit tests', () => {
 
     deployCommandsSpy.mockRestore();
     buyPollReactionHandlerSpy.mockRestore();
+    fundPollReactionHandlerSpy.mockRestore();
     sweepPollReactionHandlerSpy.mockRestore();
     loginSpy.mockRestore();
+    await returnValue?.stop?.();
+  });
+
+  test('should call `messageReactionRemove` handlers', async () => {
+    const discord = await import('discord.js');
+
+    const buyPollRemoveReactionHandler = await import(
+      './handlers/buy/buyPollRemoveReactionHandler'
+    );
+    const fundPollRemoveReactionHandler = await import(
+      './handlers/fund/fundPollRemoveReactionHandler'
+    );
+
+    const loginSpy = jest
+      .spyOn(discord.Client.prototype, 'login')
+      .mockImplementation(async () => '');
+
+    const buyPollRemoveReactionHandlerSpy = jest
+      .spyOn(buyPollRemoveReactionHandler, 'buyPollRemoveReactionHandler')
+      .mockImplementation(() => null as any);
+
+    const fundPollRemoveReactionHandlerSpy = jest
+      .spyOn(fundPollRemoveReactionHandler, 'fundPollRemoveReactionHandler')
+      .mockImplementation(() => null as any);
+
+    const {tributeToolsBot} = await import('../tribute-tools/main');
+
+    const deployCommands = await import('../helpers/deployCommands');
+
+    const deployCommandsSpy = jest
+      .spyOn(deployCommands, 'deployCommands')
+      .mockImplementation(async () => {});
+
+    const returnValue = await tributeToolsBot();
+
+    // Emit `messageReactionAdd` event
+    returnValue?.client?.emit(
+      'messageReactionRemove' as any,
+      {reactionTest: 'test'},
+      {userTest: 'test'}
+    );
+
+    expect(buyPollRemoveReactionHandlerSpy).toHaveBeenCalledTimes(1);
+
+    expect(buyPollRemoveReactionHandlerSpy).toHaveBeenCalledWith({
+      reaction: {reactionTest: 'test'},
+      user: {userTest: 'test'},
+    });
+
+    // Cleanup
+
+    deployCommandsSpy.mockRestore();
+    buyPollRemoveReactionHandlerSpy.mockRestore();
+    fundPollRemoveReactionHandlerSpy.mockRestore();
+    loginSpy.mockRestore();
+    await returnValue?.stop?.();
   });
 
   test('should destroy `Client` on `stop()`', async () => {
@@ -222,6 +289,7 @@ describe('tribute-tools/main unit tests', () => {
     deployCommandsSpy.mockRestore();
     destroyClientHandlerSpy.mockRestore();
     loginSpy.mockRestore();
+    await returnValue?.stop?.();
   });
 
   test('should handle `deployCommands` error', async () => {
@@ -245,7 +313,7 @@ describe('tribute-tools/main unit tests', () => {
         throw new Error('Some bad error.');
       });
 
-    await tributeToolsBot();
+    const returnValue = await tributeToolsBot();
 
     expect(loginSpy).toHaveBeenCalledTimes(0);
 
@@ -269,5 +337,6 @@ describe('tribute-tools/main unit tests', () => {
     consoleErrorSpy.mockRestore();
     deployCommandsSpy.mockRestore();
     loginSpy.mockRestore();
+    await returnValue?.stop?.();
   });
 });

--- a/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.ts
@@ -4,7 +4,7 @@ import Application from 'koa';
 
 import {
   getTributeToolsClient,
-  setPollTxStatus,
+  notifyPollTxStatus,
 } from '../../../applications/tribute-tools';
 import {
   HTTPMethod,
@@ -181,7 +181,7 @@ export const tributeToolsTxWebhook: Application.Middleware = async (
     }
 
     // Handle tx status in discord application
-    await setPollTxStatus({
+    await notifyPollTxStatus({
       client,
       dbEntry: updateResult,
       payload: validatedPayload,

--- a/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.ts
@@ -3,6 +3,10 @@ import {z} from 'zod';
 import Application from 'koa';
 
 import {
+  getTributeToolsClient,
+  setPollTxStatus,
+} from '../../../applications/tribute-tools';
+import {
   HTTPMethod,
   TributeToolsWebhookPayload,
   TributeToolsWebhookTxStatus,
@@ -15,8 +19,12 @@ import {prisma} from '../../../singletons';
 
 const PATH: string = 'webhook/tribute-tools-tx';
 
-const NO_BODY_ERROR: string = 'No `body` was provided.';
 const INVALID_BODY_ERROR: string = 'Incorrect `body` was provided.';
+const NO_BODY_ERROR: string = 'No `body` was provided.';
+const TX_MISSING_DATA_ERROR: string = 'Missing tx data.';
+const TX_SAVE_ERROR: string = 'Something went wrong while saving the tx data.';
+const SERVER_ERROR: string =
+  'Something went wrong while processing the webhook.';
 
 const RequiredPayloadSchema = z.object({
   data: z.object({
@@ -82,7 +90,7 @@ async function storeTxData(
         });
 
       default:
-        break;
+        return undefined;
     }
   } catch (error) {
     console.error(error);
@@ -144,10 +152,11 @@ export const tributeToolsTxWebhook: Application.Middleware = async (
     return;
   }
 
-  // Store data in database
   try {
+    // Store data in database
     const updateResult = await storeTxData(validatedPayload);
 
+    // If `uuid` was not found
     if (updateResult === null) {
       createHTTPError({
         ctx,
@@ -157,9 +166,31 @@ export const tributeToolsTxWebhook: Application.Middleware = async (
 
       return;
     }
+
+    // If the switch `default` case was chosen
+    if (updateResult === undefined) {
+      throw new Error(TX_SAVE_ERROR);
+    }
+
+    const {txHash, txStatus} = updateResult;
+
+    const {client} = await getTributeToolsClient();
+
+    if (!txHash || !txStatus) {
+      throw new Error(TX_MISSING_DATA_ERROR);
+    }
+
+    // Handle tx status in discord application
+    await setPollTxStatus({
+      client,
+      dbEntry: updateResult,
+      payload: validatedPayload,
+    });
   } catch (error) {
+    console.error(error);
+
     if (error instanceof Error) {
-      createHTTPError({ctx, message: error.message, status: 500});
+      createHTTPError({ctx, message: SERVER_ERROR, status: 500});
     }
 
     return;

--- a/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.unit.test.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.unit.test.ts
@@ -2,14 +2,11 @@ import {AddressInfo} from 'node:net';
 import {Prisma} from '@prisma/client';
 import fetch from 'node-fetch';
 
-import {
-  TributeToolsWebhookTxStatus,
-  TributeToolsWebhookTxType,
-} from '../../types';
 import {BYTES32_FIXTURE, UUID_FIXTURE} from '../../../../test/fixtures';
 import {HTTP_API_BASE_PATH} from '../../config';
 import {httpServer} from '../../httpServer';
 import {prismaMock} from '../../../../test/prismaMock';
+import {TributeToolsWebhookTxStatus} from '../../types';
 
 describe('tributeToolsTxWebhook unit tests', () => {
   const server = httpServer({noLog: true, useAnyAvailablePort: true});
@@ -85,11 +82,11 @@ describe('tributeToolsTxWebhook unit tests', () => {
     ).update.mockResolvedValue({txHash: BYTES32_FIXTURE, txStatus: 'success'});
 
     const setPollTxStatus = await import(
-      '../../../applications/tribute-tools/handlers/setPollTxStatus'
+      '../../../applications/tribute-tools/handlers/notifyPollTxStatus'
     );
 
     const setPollTxStatusSpy = jest
-      .spyOn(setPollTxStatus, 'setPollTxStatus')
+      .spyOn(setPollTxStatus, 'notifyPollTxStatus')
       .mockImplementation(async () => {});
 
     const discordLoginSpy = jest

--- a/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.unit.test.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.unit.test.ts
@@ -84,6 +84,10 @@ describe('tributeToolsTxWebhook unit tests', () => {
       prismaMock.fundAddressPoll as any
     ).update.mockResolvedValue({});
 
+    jest
+      .spyOn((await import('discord.js')).Client.prototype, 'login')
+      .mockImplementation(async () => '');
+
     // Temporarily hide warnings from `msw`
     const consoleWarnSpy = jest
       .spyOn(console, 'warn')
@@ -460,7 +464,7 @@ describe('tributeToolsTxWebhook unit tests', () => {
 
     expect(await sweepResponse.json()).toEqual({
       error: {
-        message: `Something went wrong while saving the transaction data for type \`${TributeToolsWebhookTxType.SWEEP}\` uuid \`${UUID_FIXTURE}\`\.`,
+        message: `Something went wrong while processing the webhook.`,
         status: 500,
       },
     });
@@ -468,10 +472,14 @@ describe('tributeToolsTxWebhook unit tests', () => {
     expect(floorSweeperPollSpy).toHaveBeenCalledTimes(1);
     expect(floorSweeperPollSpy).toHaveBeenNthCalledWith(1, DB_PAYLOAD);
 
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
 
     expect(consoleErrorSpy.mock.calls[0][0]?.message).toMatch(
       /some bad error/i
+    );
+
+    expect(consoleErrorSpy.mock.calls[1][0]?.message).toMatch(
+      /something went wrong while saving the transaction data for type `sweep` uuid `02458ff0-4cc5-4137-bcf5-ef91053ab811`\./i
     );
 
     // Cleanup

--- a/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.unit.test.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.unit.test.ts
@@ -74,17 +74,25 @@ describe('tributeToolsTxWebhook unit tests', () => {
 
     const buyNFTPollSpy = (
       prismaMock.buyNFTPoll as any
-    ).update.mockResolvedValue({});
+    ).update.mockResolvedValue({txHash: BYTES32_FIXTURE, txStatus: 'success'});
 
     const floorSweeperPollSpy = (
       prismaMock.floorSweeperPoll as any
-    ).update.mockResolvedValue({});
+    ).update.mockResolvedValue({txHash: BYTES32_FIXTURE, txStatus: 'success'});
 
     const fundAddressPollSpy = (
       prismaMock.fundAddressPoll as any
-    ).update.mockResolvedValue({});
+    ).update.mockResolvedValue({txHash: BYTES32_FIXTURE, txStatus: 'success'});
 
-    jest
+    const setPollTxStatus = await import(
+      '../../../applications/tribute-tools/handlers/setPollTxStatus'
+    );
+
+    const setPollTxStatusSpy = jest
+      .spyOn(setPollTxStatus, 'setPollTxStatus')
+      .mockImplementation(async () => {});
+
+    const discordLoginSpy = jest
       .spyOn((await import('discord.js')).Client.prototype, 'login')
       .mockImplementation(async () => '');
 
@@ -133,6 +141,8 @@ describe('tributeToolsTxWebhook unit tests', () => {
 
     // Cleanup
     consoleWarnSpy.mockRestore();
+    discordLoginSpy.mockRestore();
+    setPollTxStatusSpy.mockRestore();
   });
 
   test('should return `400` response when no `body`', async () => {


### PR DESCRIPTION
Fixes #95 

🥳 **Adds**

- `notifyPollTxStatus` handler for displaying a poll's transaction status
- `docker:migrate:dev` helper `package.json` script
- DB migration for adding `actionMessageID` column to `buy_nft_poll`, `floor_sweeper_poll`, `fund_address_poll`
- `getTributeToolsClient` helper to access instantiated Tribute Tools app Discord `Client` throughout app.

✨ **Updates**

- Tribute Tools app `Client` usages refactored with `getTributeToolsClient`
- `tributeToolsTxWebhook` API middleware now uses `notifyPollTxStatus`
- `README` DB migrations instructions
- Stores `actionMessageID` in database for `/buy`, `/fund`, `/sweep`


