### PR TITLE
Display original ETH price of `/buy` polls in corresponding messages

### DIFF
--- a/prisma/migrations/20220308145646_/migration.sql
+++ b/prisma/migrations/20220308145646_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "buy_nft_poll" ADD COLUMN     "amountWEI" DECIMAL(78,0) NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,7 @@ model BuyNFTPoll {
   name            String                @db.VarChar(255)
   contractAddress String                @db.VarChar(255)
   tokenID         String                @db.VarChar(255)
+  amountWEI       Decimal               @default(0) @db.Decimal(78, 0)
   processed       Boolean               @default(false) @db.Boolean
   voteThreshold   Int                   @default(0) @db.Integer
   upvoteCount     Int                   @default(0) @db.Integer

--- a/src/applications/tribute-tools/commands/buy.ts
+++ b/src/applications/tribute-tools/commands/buy.ts
@@ -298,6 +298,7 @@ async function execute(interaction: CommandInteraction) {
     // Store poll data in DB
     await prisma.buyNFTPoll.create({
       data: {
+        amountWEI: priceInfo.price,
         channelID,
         contractAddress,
         guildID,

--- a/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.ts
+++ b/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.ts
@@ -9,6 +9,7 @@ import {
   User,
 } from 'discord.js';
 import {channelMention, time} from '@discordjs/builders';
+import {fromWei, toBN} from 'web3-utils';
 
 import {THUMBS_EMOJIS, BUY_EXTERNAL_URL} from '../../config';
 import {getDaoDataByGuildID} from '../../../../helpers';
@@ -128,6 +129,7 @@ export async function buyPollReactionHandler({
     });
 
     const {
+      amountWEI,
       channelID,
       contractAddress,
       guildID,
@@ -199,7 +201,10 @@ export async function buyPollReactionHandler({
             .setEmoji('💸')
         );
 
-        const content: string = `The poll for "*${name}*" ended ${time(
+        const content: string = `The poll for "*${name}*" @ ${fromWei(
+          toBN(amountWEI.toString()),
+          'ether'
+        )} ETH ended ${time(
           Math.floor(Date.now() / 1000),
           'R'
         )}. The threshold of ${voteThreshold} vote${

--- a/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.unit.test.ts
@@ -6,8 +6,10 @@ import {
   PartialUser,
   User,
 } from 'discord.js';
+import {BuyNFTPoll, Prisma} from '@prisma/client';
 
 import {
+  BYTES32_FIXTURE,
   ETH_ADDRESS_FIXTURE,
   FAKE_DAOS_FIXTURE,
   GUILD_ID_FIXTURE,
@@ -115,7 +117,9 @@ describe('buyPollReactionHandler unit tests', () => {
 
     const USER: User | PartialUser = {bot: false, id: '123'} as any;
 
-    const DB_ENTRY = {
+    const DB_ENTRY: BuyNFTPoll = {
+      actionMessageID: 'abc123',
+      amountWEI: new Prisma.Decimal('2200000000000000000'),
       channelID: '886976610018934824',
       contractAddress: ETH_ADDRESS_FIXTURE,
       createdAt: new Date(0),
@@ -125,6 +129,8 @@ describe('buyPollReactionHandler unit tests', () => {
       name: 'Test Punk #123',
       processed: false,
       tokenID: '123',
+      txHash: BYTES32_FIXTURE,
+      txStatus: 'success',
       upvoteCount: 4,
       uuid: 'abc123def456',
       voteThreshold: 5,
@@ -190,7 +196,7 @@ describe('buyPollReactionHandler unit tests', () => {
     expect(channelSendSpy).toHaveBeenCalledTimes(1);
 
     expect(channelSendSpy.mock.calls[0][0].content).toMatch(
-      /The poll for "\*Test Punk #123\*" ended <t:\d+:R>\. The threshold of 5 votes has been reached\./i
+      /The poll for "\*Test Punk #123\*" @ 2.2 ETH ended <t:\d+:R>\. The threshold of 5 votes has been reached\./i
     );
 
     expect(channelSendSpy.mock.calls[0][0].components).toEqual([BUY_BUTTON]);
@@ -205,7 +211,7 @@ describe('buyPollReactionHandler unit tests', () => {
     );
 
     expect(messageReplySpy.mock.calls[0][0].embeds[0].description).toMatch(
-      /The poll for "\*Test Punk #123\*" ended <t:\d+:R>\. The threshold of 5 votes has been reached\./i
+      /The poll for "\*Test Punk #123\*" @ 2.2 ETH ended <t:\d+:R>\. The threshold of 5 votes has been reached\./i
     );
 
     // Cleanup

--- a/src/applications/tribute-tools/handlers/notifyPollTxStatus.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/notifyPollTxStatus.unit.test.ts
@@ -2,6 +2,7 @@ import {
   BuyNFTPoll,
   FloorSweeperPoll,
   FundAddressPoll,
+  Prisma,
   TributeToolsTxStatus,
 } from '@prisma/client';
 import {Client, Intents, MessageEmbed} from 'discord.js';
@@ -39,6 +40,7 @@ describe('notifyPollTxStatus unit tests', () => {
   };
 
   const BUY_DB_ENTRY: BuyNFTPoll = {
+    amountWEI: new Prisma.Decimal('2200000000000000000'),
     actionMessageID: '987654321',
     channelID: '123456789',
     contractAddress: ETH_ADDRESS_FIXTURE,


### PR DESCRIPTION
Fixes #103 

🥳 **Adds**

- Adds `amountWEI` column to `buy_nft_poll`

✨ **Updates**

- Adds `amountWEI` to DB data in `/buy` command
- Adds ETH amount in corresponding messages when a `/buy` poll ends

