### PR TITLE
adds `id=<UUID>` to `/fund` Tribute Tools `LINK`

### DIFF
--- a/src/applications/tribute-tools/handlers/fund/fundPollReactionHandler.ts
+++ b/src/applications/tribute-tools/handlers/fund/fundPollReactionHandler.ts
@@ -134,6 +134,7 @@ export async function fundPollReactionHandler({
       messageID,
       purpose,
       upvoteCount,
+      uuid,
       voteThreshold,
     } = pollEntry;
 
@@ -192,7 +193,7 @@ export async function fundPollReactionHandler({
             .setLabel('Fund')
             .setStyle('LINK')
             .setURL(
-              `${FUND_EXTERNAL_URL}/?daoName=${dao.internalName}&amount=${amountUSDC}`
+              `${FUND_EXTERNAL_URL}/?daoName=${dao.internalName}&amount=${amountUSDC}&id=${uuid}`
             )
             .setEmoji('💸')
         );

--- a/src/applications/tribute-tools/handlers/fund/fundPollReactionHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/fund/fundPollReactionHandler.unit.test.ts
@@ -159,7 +159,7 @@ describe('fundPollReactionHandler unit tests', () => {
         .setLabel('Fund')
         .setStyle('LINK')
         .setURL(
-          `${FUND_EXTERNAL_URL}/?daoName=test&amount=${DB_ENTRY.amountUSDC}`
+          `${FUND_EXTERNAL_URL}/?daoName=test&amount=${DB_ENTRY.amountUSDC}&id=${DB_ENTRY.uuid}`
         )
         .setEmoji('💸')
     );


### PR DESCRIPTION
Fixes #105 


🐞 **Bugs squashed**

- Adds `uuid` to external `LINK` URL for the Tribute Tools fund action.

