### PR TITLE
Mark poll as cancelled

### DIFF
--- a/prisma/migrations/20220310141922_/migration.sql
+++ b/prisma/migrations/20220310141922_/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "buy_nft_poll" ADD COLUMN     "isCancelled" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "floor_sweeper_poll" ADD COLUMN     "isCancelled" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "fund_address_poll" ADD COLUMN     "isCancelled" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,7 @@ model FloorSweeperPoll {
   actionMessageID String?               @unique @db.VarChar(255)
   txStatus        TributeToolsTxStatus?
   txHash          String?               @db.VarChar(255)
+  isCancelled     Boolean               @default(false) @db.Boolean
 
   @@map("floor_sweeper_poll")
 }
@@ -67,6 +68,7 @@ model BuyNFTPoll {
   actionMessageID String?               @unique @db.VarChar(255)
   txStatus        TributeToolsTxStatus?
   txHash          String?               @db.VarChar(255)
+  isCancelled     Boolean               @default(false) @db.Boolean
 
   @@map("buy_nft_poll")
 }
@@ -87,6 +89,7 @@ model FundAddressPoll {
   actionMessageID String?               @unique @db.VarChar(255)
   txStatus        TributeToolsTxStatus?
   txHash          String?               @db.VarChar(255)
+  isCancelled     Boolean               @default(false) @db.Boolean
 
   @@map("fund_address_poll")
 }

--- a/src/applications/tribute-tools/commands/buy.ts
+++ b/src/applications/tribute-tools/commands/buy.ts
@@ -10,12 +10,12 @@ import {SlashCommandBuilder} from '@discordjs/builders';
 import {URL} from 'url';
 import fetch from 'node-fetch';
 
+import {CANCEL_POLL_BUY_CUSTOM_ID, THUMBS_EMOJIS} from '../config';
 import {Command} from '../../types';
 import {getDaoDataByGuildID, getEnv} from '../../../helpers';
 import {getDaos} from '../../../services';
 import {getVoteThreshold} from '../helpers';
 import {prisma} from '../../../singletons';
-import {CANCEL_POLL_BUY_CUSTOM_ID, THUMBS_EMOJIS} from '../config';
 
 const COMMAND_NAME: string = 'buy';
 

--- a/src/applications/tribute-tools/commands/buy.ts
+++ b/src/applications/tribute-tools/commands/buy.ts
@@ -1,4 +1,10 @@
-import {CommandInteraction, Message, MessageEmbed} from 'discord.js';
+import {
+  CommandInteraction,
+  Message,
+  MessageActionRow,
+  MessageButton,
+  MessageEmbed,
+} from 'discord.js';
 import {isAddress, fromWei, toBN} from 'web3-utils';
 import {SlashCommandBuilder} from '@discordjs/builders';
 import {URL} from 'url';
@@ -9,7 +15,7 @@ import {getDaoDataByGuildID, getEnv} from '../../../helpers';
 import {getDaos} from '../../../services';
 import {getVoteThreshold} from '../helpers';
 import {prisma} from '../../../singletons';
-import {THUMBS_EMOJIS} from '../config';
+import {CANCEL_POLL_BUY_CUSTOM_ID, THUMBS_EMOJIS} from '../config';
 
 const COMMAND_NAME: string = 'buy';
 
@@ -280,8 +286,16 @@ async function execute(interaction: CommandInteraction) {
       text: 'After a threshold has been reached the vote is final,\neven if you change your vote.',
     });
 
+  const cancelButton = new MessageActionRow().addComponents(
+    new MessageButton()
+      .setCustomId(CANCEL_POLL_BUY_CUSTOM_ID)
+      .setLabel('Cancel poll')
+      .setStyle('SECONDARY')
+  );
+
   // Reply to user
   const message = (await interaction.reply({
+    components: [cancelButton],
     embeds: [embed],
     fetchReply: true,
   })) as Message;

--- a/src/applications/tribute-tools/commands/buy.unit.test.ts
+++ b/src/applications/tribute-tools/commands/buy.unit.test.ts
@@ -3,6 +3,8 @@ import {
   ClientOptions,
   Intents,
   InteractionReplyOptions,
+  MessageActionRow,
+  MessageButton,
 } from 'discord.js';
 import {RawInteractionData} from 'discord.js/typings/rawDataTypes';
 
@@ -13,6 +15,7 @@ import {
   GUILD_ID_FIXTURE,
 } from '../../../../test';
 import {buy} from './buy';
+import {CANCEL_POLL_BUY_CUSTOM_ID} from '../config';
 import {prismaMock} from '../../../../test/prismaMock';
 import {rest, server} from '../../../../test/msw/server';
 
@@ -226,6 +229,18 @@ describe('buy unit tests', () => {
       (interactionReplySpy.mock.calls[0][0] as InteractionReplyOptions)
         .embeds?.[0]?.fields
     ).toEqual([{inline: false, name: 'Vote Threshold', value: '3 upvotes'}]);
+
+    expect(
+      (interactionReplySpy.mock.calls[0][0] as InteractionReplyOptions)
+        .components
+    ).toEqual([
+      new MessageActionRow().addComponents(
+        new MessageButton()
+          .setCustomId(CANCEL_POLL_BUY_CUSTOM_ID)
+          .setLabel('Cancel poll')
+          .setStyle('SECONDARY')
+      ),
+    ]);
 
     expect(reactSpy.mock.calls.length).toBe(2);
     expect(reactSpy.mock.calls).toEqual([['👍'], ['👎']]);

--- a/src/applications/tribute-tools/commands/fund.ts
+++ b/src/applications/tribute-tools/commands/fund.ts
@@ -1,4 +1,10 @@
-import {CommandInteraction, Message, MessageEmbed} from 'discord.js';
+import {
+  CommandInteraction,
+  Message,
+  MessageActionRow,
+  MessageButton,
+  MessageEmbed,
+} from 'discord.js';
 import {SlashCommandBuilder} from '@discordjs/builders';
 
 import {Command} from '../../types';
@@ -6,7 +12,7 @@ import {DEV_COMMAND_NOT_READY} from '../helpers';
 import {getDaoDataByGuildID, normalizeString} from '../../../helpers';
 import {getDaos} from '../../../services';
 import {prisma, web3} from '../../../singletons';
-import {THUMBS_EMOJIS} from '../config';
+import {CANCEL_POLL_FUND_CUSTOM_ID, THUMBS_EMOJIS} from '../config';
 
 const COMMAND_NAME: string = 'fund';
 
@@ -135,8 +141,16 @@ async function execute(interaction: CommandInteraction) {
       text: 'After a threshold has been reached the vote is final,\neven if you change your vote.',
     });
 
+  const cancelButton = new MessageActionRow().addComponents(
+    new MessageButton()
+      .setCustomId(CANCEL_POLL_FUND_CUSTOM_ID)
+      .setLabel('Cancel poll')
+      .setStyle('SECONDARY')
+  );
+
   // Reply to user
   const message = (await interaction.reply({
+    components: [cancelButton],
     embeds: [embed],
     fetchReply: true,
   })) as Message;

--- a/src/applications/tribute-tools/commands/fund.unit.test.ts
+++ b/src/applications/tribute-tools/commands/fund.unit.test.ts
@@ -3,6 +3,8 @@ import {
   ClientOptions,
   Intents,
   InteractionReplyOptions,
+  MessageActionRow,
+  MessageButton,
 } from 'discord.js';
 import {RawInteractionData} from 'discord.js/typings/rawDataTypes';
 
@@ -12,10 +14,10 @@ import {
   FakeDiscordCommandInteraction,
   GUILD_ID_FIXTURE,
 } from '../../../../test';
-import {prismaMock} from '../../../../test/prismaMock';
+import {CANCEL_POLL_FUND_CUSTOM_ID, THUMBS_EMOJIS} from '../config';
 import {DaoData} from '../../../config';
-import {THUMBS_EMOJIS} from '../config';
 import {fund} from './fund';
+import {prismaMock} from '../../../../test/prismaMock';
 
 describe('fund unit tests', () => {
   const CLIENT_OPTIONS: ClientOptions = {
@@ -166,6 +168,18 @@ describe('fund unit tests', () => {
       (interactionReplySpy.mock.calls[0][0] as InteractionReplyOptions)
         .embeds?.[0]?.fields?.[0].value
     ).toMatch(/3 upvotes/i);
+
+    expect(
+      (interactionReplySpy.mock.calls[0][0] as InteractionReplyOptions)
+        .components
+    ).toEqual([
+      new MessageActionRow().addComponents(
+        new MessageButton()
+          .setCustomId(CANCEL_POLL_FUND_CUSTOM_ID)
+          .setLabel('Cancel poll')
+          .setStyle('SECONDARY')
+      ),
+    ]);
 
     expect(reactSpy).toHaveBeenCalledTimes(2);
     expect(reactSpy).toHaveBeenNthCalledWith(1, THUMBS_EMOJIS[0]);

--- a/src/applications/tribute-tools/commands/sweep.ts
+++ b/src/applications/tribute-tools/commands/sweep.ts
@@ -8,12 +8,15 @@ import {
   CommandInteraction,
   CommandInteractionOption,
   Message,
+  MessageActionRow,
+  MessageButton,
   MessageEmbed,
 } from 'discord.js';
 import dayjs from 'dayjs';
 import duration, {DurationUnitType} from 'dayjs/plugin/duration';
 
 import {
+  CANCEL_POLL_SWEEP_CUSTOM_ID,
   NO_ENTRY_SIGN_EMOJI,
   POLL_REACTION_EMOJIS,
   REGIONAL_INDICATOR_PREFIX,
@@ -261,8 +264,16 @@ async function execute(interaction: CommandInteraction) {
       value: time(dateEnd, 'F'),
     });
 
+  const cancelButton = new MessageActionRow().addComponents(
+    new MessageButton()
+      .setCustomId(CANCEL_POLL_SWEEP_CUSTOM_ID)
+      .setLabel('Cancel poll')
+      .setStyle('SECONDARY')
+  );
+
   // Reply with user's title and options chosen
   const message = (await interaction.reply({
+    components: [cancelButton],
     content: `📊 ${bold(question)}\n`,
     embeds: [pollOptionsEmbed],
     fetchReply: true,

--- a/src/applications/tribute-tools/commands/sweep.unit.test.ts
+++ b/src/applications/tribute-tools/commands/sweep.unit.test.ts
@@ -3,6 +3,8 @@ import {
   ClientOptions,
   Intents,
   InteractionReplyOptions,
+  MessageActionRow,
+  MessageButton,
 } from 'discord.js';
 import {RawInteractionData} from 'discord.js/typings/rawDataTypes';
 
@@ -10,6 +12,7 @@ import {
   ETH_ADDRESS_FIXTURE,
   FakeDiscordCommandInteraction,
 } from '../../../../test';
+import {CANCEL_POLL_SWEEP_CUSTOM_ID} from '../config';
 import {prismaMock} from '../../../../test/prismaMock';
 import {sweep} from './sweep';
 
@@ -155,6 +158,18 @@ describe('sweep unit tests', () => {
       (interactionReplySpy.mock.calls[0][0] as InteractionReplyOptions)
         .embeds?.[0]?.fields?.[0].name
     ).toMatch(/⏱ poll ends:/i);
+
+    expect(
+      (interactionReplySpy.mock.calls[0][0] as InteractionReplyOptions)
+        .components
+    ).toEqual([
+      new MessageActionRow().addComponents(
+        new MessageButton()
+          .setCustomId(CANCEL_POLL_SWEEP_CUSTOM_ID)
+          .setLabel('Cancel poll')
+          .setStyle('SECONDARY')
+      ),
+    ]);
 
     expect(reactSpy.mock.calls.length).toBe(4);
     expect(reactSpy.mock.calls).toEqual([['🇦'], ['🇧'], ['🇨'], ['🚫']]);

--- a/src/applications/tribute-tools/config.ts
+++ b/src/applications/tribute-tools/config.ts
@@ -38,3 +38,6 @@ export const BUY_EXTERNAL_URL: string = `${TRIBUTE_TOOLS_URL}/single-buy`;
 export const FUND_EXTERNAL_URL: string = `${TRIBUTE_TOOLS_URL}/fund`;
 export const SWEEP_EXTERNAL_URL: string = `${TRIBUTE_TOOLS_URL}/floor-sweeper`;
 export const THUMBS_EMOJIS = ['👍', '👎'] as const;
+export const CANCEL_POLL_BUY_CUSTOM_ID: string = 'cancelBuyPoll';
+export const CANCEL_POLL_FUND_CUSTOM_ID: string = 'cancelFundPoll';
+export const CANCEL_POLL_SWEEP_CUSTOM_ID: string = 'cancelSweepPoll';

--- a/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/buy/buyPollReactionHandler.unit.test.ts
@@ -125,6 +125,7 @@ describe('buyPollReactionHandler unit tests', () => {
       createdAt: new Date(0),
       guildID: GUILD_ID_FIXTURE,
       id: 1,
+      isCancelled: false,
       messageID: 'abc123',
       name: 'Test Punk #123',
       processed: false,

--- a/src/applications/tribute-tools/handlers/cancelPollHandler.ts
+++ b/src/applications/tribute-tools/handlers/cancelPollHandler.ts
@@ -64,10 +64,8 @@ async function getPollTitle({
         );
     }
   } catch (error) {
-    console.error(error);
-
     throw new Error(
-      `Something went wrong while getting the poll data for application command \`${applicationCommandName}\`.`
+      `Something went wrong while getting the poll data for application command \`${applicationCommandName}\`: ${error}`
     );
   }
 }

--- a/src/applications/tribute-tools/handlers/cancelPollHandler.ts
+++ b/src/applications/tribute-tools/handlers/cancelPollHandler.ts
@@ -1,0 +1,124 @@
+import {Interaction, MessageActionRow, MessageButton} from 'discord.js';
+
+import {
+  CANCEL_POLL_BUY_CUSTOM_ID,
+  CANCEL_POLL_FUND_CUSTOM_ID,
+  CANCEL_POLL_SWEEP_CUSTOM_ID,
+} from '../config';
+import {APPLICATION_COMMANDS} from '../../../config';
+import {prisma} from '../../../singletons';
+
+type ApplicationCommands = typeof APPLICATION_COMMANDS[number];
+
+type ConfirmCancelPollCustomID =
+  `confirmCancelPoll-${ApplicationCommands}-${string}`;
+
+function getCommandFromCustomID(
+  customId: string
+): ApplicationCommands | undefined {
+  switch (customId) {
+    case CANCEL_POLL_BUY_CUSTOM_ID:
+      return 'BUY';
+    case CANCEL_POLL_FUND_CUSTOM_ID:
+      return 'FUND';
+    case CANCEL_POLL_SWEEP_CUSTOM_ID:
+      return 'SWEEP';
+    default:
+      return undefined;
+  }
+}
+
+async function getPollTitle({
+  applicationCommand,
+  messageID,
+}: {
+  applicationCommand: ApplicationCommands;
+  messageID: string;
+}): Promise<string | undefined> {
+  try {
+    switch (applicationCommand) {
+      case 'BUY':
+        return (
+          await prisma.buyNFTPoll.findUnique({
+            where: {messageID},
+          })
+        )?.name;
+
+      case 'FUND':
+        return (
+          await prisma.fundAddressPoll.findUnique({
+            where: {messageID},
+          })
+        )?.purpose;
+
+      case 'SWEEP':
+        return (
+          await prisma.floorSweeperPoll.findUnique({
+            where: {messageID},
+          })
+        )?.question;
+
+      default:
+        throw new Error(
+          `Could not find \`APPLICATION_COMMANDS\`: \`${applicationCommand}\`.`
+        );
+    }
+  } catch (error) {
+    console.error(error);
+
+    throw new Error(
+      `Something went wrong while getting the poll data for application command \`${applicationCommand}\`.`
+    );
+  }
+}
+
+export async function cancelPollHandler(
+  interaction: Interaction
+): Promise<void> {
+  // If the interaction is not from a button, exit.
+  if (!interaction.isButton()) return;
+
+  const applicationCommand = getCommandFromCustomID(interaction.customId);
+
+  // If no matching `customId` is found, exit.
+  if (!applicationCommand) return;
+
+  try {
+    const messageID: string = interaction.message.id;
+
+    const pollTitle = await getPollTitle({applicationCommand, messageID});
+
+    if (!pollTitle) {
+      throw new Error(
+        `No poll title was found for message \`${messageID}\` in guild \`${interaction.guildId}\`.`
+      );
+    }
+
+    const customId: ConfirmCancelPollCustomID = `confirmCancelPoll-${applicationCommand}-${messageID}`;
+
+    const confirmCancelButton = new MessageActionRow().addComponents(
+      new MessageButton()
+        .setCustomId(customId)
+        .setLabel('Cancel poll')
+        .setStyle('DANGER')
+    );
+
+    // Respond with a confirmation message and button
+    await interaction.reply({
+      components: [confirmCancelButton],
+      content: `You're about to cancel and remove the poll, *${pollTitle}*`,
+      ephemeral: true,
+    });
+  } catch (error) {
+    console.error(error);
+
+    try {
+      await interaction.reply({
+        content: `There was an error while trying to cancel the poll.`,
+        ephemeral: true,
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  }
+}

--- a/src/applications/tribute-tools/handlers/cancelPollHandler.ts
+++ b/src/applications/tribute-tools/handlers/cancelPollHandler.ts
@@ -29,14 +29,14 @@ function getCommandFromCustomID(
 }
 
 async function getPollTitle({
-  applicationCommand,
+  applicationCommandName,
   messageID,
 }: {
-  applicationCommand: ApplicationCommands;
+  applicationCommandName: ApplicationCommands;
   messageID: string;
 }): Promise<string | undefined> {
   try {
-    switch (applicationCommand) {
+    switch (applicationCommandName) {
       case 'BUY':
         return (
           await prisma.buyNFTPoll.findUnique({
@@ -60,14 +60,14 @@ async function getPollTitle({
 
       default:
         throw new Error(
-          `Could not find \`APPLICATION_COMMANDS\`: \`${applicationCommand}\`.`
+          `Could not find \`APPLICATION_COMMANDS\`: \`${applicationCommandName}\`.`
         );
     }
   } catch (error) {
     console.error(error);
 
     throw new Error(
-      `Something went wrong while getting the poll data for application command \`${applicationCommand}\`.`
+      `Something went wrong while getting the poll data for application command \`${applicationCommandName}\`.`
     );
   }
 }
@@ -78,15 +78,15 @@ export async function cancelPollHandler(
   // If the interaction is not from a button, exit.
   if (!interaction.isButton()) return;
 
-  const applicationCommand = getCommandFromCustomID(interaction.customId);
+  const applicationCommandName = getCommandFromCustomID(interaction.customId);
 
   // If no matching `customId` is found, exit.
-  if (!applicationCommand) return;
+  if (!applicationCommandName) return;
 
   try {
     const messageID: string = interaction.message.id;
 
-    const pollTitle = await getPollTitle({applicationCommand, messageID});
+    const pollTitle = await getPollTitle({applicationCommandName, messageID});
 
     if (!pollTitle) {
       throw new Error(
@@ -94,7 +94,7 @@ export async function cancelPollHandler(
       );
     }
 
-    const customId: ConfirmCancelPollCustomID = `confirmCancelPoll-${applicationCommand}-${messageID}`;
+    const customId: ConfirmCancelPollCustomID = `confirmCancelPoll-${applicationCommandName}-${messageID}`;
 
     const confirmCancelButton = new MessageActionRow().addComponents(
       new MessageButton()

--- a/src/applications/tribute-tools/handlers/cancelPollHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/cancelPollHandler.unit.test.ts
@@ -1,0 +1,174 @@
+import {CommandInteraction, MessageActionRow, MessageButton} from 'discord.js';
+
+import {
+  BYTES32_FIXTURE,
+  ETH_ADDRESS_FIXTURE,
+  GUILD_ID_FIXTURE,
+} from '../../../../test';
+import {CANCEL_POLL_SWEEP_CUSTOM_ID} from '../config';
+import {cancelPollHandler} from './cancelPollHandler';
+import {FloorSweeperPoll} from '@prisma/client';
+import {prismaMock} from '../../../../test/prismaMock';
+
+describe('cancelPollHandler unit tests', () => {
+  const DEFAULT_DB_ENTRY: FloorSweeperPoll = {
+    actionMessageID: '123456789',
+    channelID: '886976610018934824',
+    contractAddress: ETH_ADDRESS_FIXTURE,
+    createdAt: new Date(0),
+    dateEnd: new Date(10),
+    guildID: GUILD_ID_FIXTURE,
+    id: 1,
+    isCancelled: true,
+    messageID: '123456789',
+    options: {'🇦': 50, '🇧': 100, '🇨': 150, '🚫': 'None'},
+    processed: false,
+    question: 'How much to sweep larvalads fam?',
+    result: 0,
+    txHash: BYTES32_FIXTURE,
+    txStatus: 'success',
+    uuid: 'abc123def456',
+  };
+
+  test('should send user ephemeral message to cancel a poll', async () => {
+    const replySpy = jest.fn();
+
+    const FAKE_INTERACTION = {
+      customId: CANCEL_POLL_SWEEP_CUSTOM_ID,
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => true,
+      message: {
+        id: '123456789',
+      },
+      reply: replySpy,
+    } as any as CommandInteraction;
+
+    const CONFIRM_CANCEL_BUTTON = new MessageActionRow().addComponents(
+      new MessageButton()
+        .setCustomId('confirmCancelPoll-SWEEP-123456789')
+        .setLabel('Cancel poll')
+        .setStyle('DANGER')
+    );
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbfindMock = (
+      prismaMock.floorSweeperPoll as any
+    ).findUnique.mockResolvedValue(DEFAULT_DB_ENTRY);
+
+    await cancelPollHandler(FAKE_INTERACTION);
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+
+    expect(replySpy).toHaveBeenNthCalledWith(1, {
+      components: [CONFIRM_CANCEL_BUTTON],
+      content: `You're about to cancel and remove the poll, *${DEFAULT_DB_ENTRY.question}*`,
+      ephemeral: true,
+    });
+
+    expect(dbfindMock).toHaveBeenCalledTimes(1);
+
+    expect(dbfindMock).toHaveBeenNthCalledWith(1, {
+      where: {
+        messageID: '123456789',
+      },
+    });
+
+    // Cleanup
+
+    dbfindMock.mockRestore();
+  });
+
+  test('should exit if no matching `customId` was found', async () => {
+    const replySpy = jest.fn();
+
+    const FAKE_INTERACTION = {
+      // Use a bad `customId`
+      customId: 'badId',
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => true,
+      message: {
+        id: '123456789',
+      },
+      reply: replySpy,
+    } as any as CommandInteraction;
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbfindMock = (
+      prismaMock.floorSweeperPoll as any
+    ).findUnique.mockResolvedValue(DEFAULT_DB_ENTRY);
+
+    await cancelPollHandler(FAKE_INTERACTION);
+
+    expect(replySpy).toHaveBeenCalledTimes(0);
+    expect(dbfindMock).toHaveBeenCalledTimes(0);
+
+    // Cleanup
+
+    dbfindMock.mockRestore();
+  });
+
+  test('should handle error if `findUnique` throws', async () => {
+    const replySpy = jest.fn();
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const FAKE_INTERACTION = {
+      customId: CANCEL_POLL_SWEEP_CUSTOM_ID,
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => true,
+      message: {
+        id: '123456789',
+      },
+      reply: replySpy,
+    } as any as CommandInteraction;
+
+    /**
+     * Mock db error
+     *
+     * @todo fix types
+     */
+    const dbfindMock = (
+      prismaMock.floorSweeperPoll as any
+    ).findUnique.mockImplementation(() => {
+      new Error('Some bad error');
+    });
+
+    await cancelPollHandler(FAKE_INTERACTION);
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+
+    expect(replySpy).toHaveBeenNthCalledWith(1, {
+      content: `There was an error while trying to cancel the poll.`,
+      ephemeral: true,
+    });
+
+    expect(dbfindMock).toHaveBeenCalledTimes(1);
+
+    expect(dbfindMock).toHaveBeenNthCalledWith(1, {
+      where: {
+        messageID: '123456789',
+      },
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    expect(consoleErrorSpy.mock.calls[0][0]?.message).toMatch(
+      /No poll title was found for message `123456789` in guild `123123123123123123`\./i
+    );
+
+    // Cleanup
+
+    dbfindMock.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/applications/tribute-tools/handlers/cancelPollHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/cancelPollHandler.unit.test.ts
@@ -78,9 +78,23 @@ describe('cancelPollHandler unit tests', () => {
     voteThreshold: 3,
   };
 
-  const DEFAULT_CANCEL_BUTTON = new MessageActionRow().addComponents(
+  const DEFAULT_CANCEL_SWEEP_BUTTON = new MessageActionRow().addComponents(
     new MessageButton()
       .setCustomId('confirmCancelPoll-SWEEP-123456789')
+      .setLabel('Cancel poll')
+      .setStyle('DANGER')
+  );
+
+  const DEFAULT_CANCEL_BUY_BUTTON = new MessageActionRow().addComponents(
+    new MessageButton()
+      .setCustomId('confirmCancelPoll-BUY-123456789')
+      .setLabel('Cancel poll')
+      .setStyle('DANGER')
+  );
+
+  const DEFAULT_CANCEL_FUND_BUTTON = new MessageActionRow().addComponents(
+    new MessageButton()
+      .setCustomId('confirmCancelPoll-FUND-123456789')
       .setLabel('Cancel poll')
       .setStyle('DANGER')
   );
@@ -134,8 +148,20 @@ describe('cancelPollHandler unit tests', () => {
     expect(replySpy).toHaveBeenCalledTimes(3);
 
     expect(replySpy).toHaveBeenNthCalledWith(1, {
-      components: [DEFAULT_CANCEL_BUTTON],
+      components: [DEFAULT_CANCEL_SWEEP_BUTTON],
       content: `You're about to cancel and remove the poll, *${DEFAULT_SWEEP_DB_ENTRY.question}*`,
+      ephemeral: true,
+    });
+
+    expect(replySpy).toHaveBeenNthCalledWith(2, {
+      components: [DEFAULT_CANCEL_BUY_BUTTON],
+      content: `You're about to cancel and remove the poll, *${DEFAULT_BUY_DB_ENTRY.name}*`,
+      ephemeral: true,
+    });
+
+    expect(replySpy).toHaveBeenNthCalledWith(3, {
+      components: [DEFAULT_CANCEL_FUND_BUTTON],
+      content: `You're about to cancel and remove the poll, *${DEFAULT_FUND_DB_ENTRY.purpose}*`,
       ephemeral: true,
     });
 
@@ -326,7 +352,7 @@ describe('cancelPollHandler unit tests', () => {
     expect(replySpy).toHaveBeenCalledTimes(2);
 
     expect(replySpy).toHaveBeenNthCalledWith(1, {
-      components: [DEFAULT_CANCEL_BUTTON],
+      components: [DEFAULT_CANCEL_SWEEP_BUTTON],
       content: `You're about to cancel and remove the poll, *${DEFAULT_SWEEP_DB_ENTRY.question}*`,
       ephemeral: true,
     });
@@ -394,7 +420,7 @@ describe('cancelPollHandler unit tests', () => {
     expect(replySpy).toHaveBeenCalledTimes(2);
 
     expect(replySpy).toHaveBeenNthCalledWith(1, {
-      components: [DEFAULT_CANCEL_BUTTON],
+      components: [DEFAULT_CANCEL_SWEEP_BUTTON],
       content: `You're about to cancel and remove the poll, *${DEFAULT_SWEEP_DB_ENTRY.question}*`,
       ephemeral: true,
     });

--- a/src/applications/tribute-tools/handlers/cancelPollHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/cancelPollHandler.unit.test.ts
@@ -19,7 +19,7 @@ describe('cancelPollHandler unit tests', () => {
     dateEnd: new Date(10),
     guildID: GUILD_ID_FIXTURE,
     id: 1,
-    isCancelled: true,
+    isCancelled: false,
     messageID: '123456789',
     options: {'🇦': 50, '🇧': 100, '🇨': 150, '🚫': 'None'},
     processed: false,

--- a/src/applications/tribute-tools/handlers/cancelPollHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/cancelPollHandler.unit.test.ts
@@ -115,6 +115,38 @@ describe('cancelPollHandler unit tests', () => {
     dbfindMock.mockRestore();
   });
 
+  test('should exit if `interaction` is not a button', async () => {
+    const replySpy = jest.fn();
+
+    const FAKE_INTERACTION = {
+      customId: CANCEL_POLL_SWEEP_CUSTOM_ID,
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => false,
+      message: {
+        id: '123456789',
+      },
+      reply: replySpy,
+    } as any as CommandInteraction;
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbfindMock = (
+      prismaMock.floorSweeperPoll as any
+    ).findUnique.mockResolvedValue(DEFAULT_DB_ENTRY);
+
+    await cancelPollHandler(FAKE_INTERACTION);
+
+    expect(replySpy).toHaveBeenCalledTimes(0);
+    expect(dbfindMock).toHaveBeenCalledTimes(0);
+
+    // Cleanup
+
+    dbfindMock.mockRestore();
+  });
+
   test('should handle error if `findUnique` throws', async () => {
     const replySpy = jest.fn();
 

--- a/src/applications/tribute-tools/handlers/confirmCancelPollHandler.ts
+++ b/src/applications/tribute-tools/handlers/confirmCancelPollHandler.ts
@@ -1,0 +1,212 @@
+import {
+  BuyNFTPoll,
+  FloorSweeperPoll,
+  FundAddressPoll,
+  Prisma,
+} from '@prisma/client';
+import {Interaction, MessageEmbed, TextChannel} from 'discord.js';
+
+import {APPLICATION_COMMANDS} from '../../../config';
+import {getTributeToolsClient} from '..';
+import {prisma} from '../../../singletons';
+import {getDaoDataByGuildID} from '../../../helpers';
+import {getDaos} from '../../../services';
+
+type ApplicationCommands = typeof APPLICATION_COMMANDS[number];
+
+const CUSTOM_ID_REGEX: RegExp = new RegExp(
+  `^confirmCancelPoll-(${APPLICATION_COMMANDS.join('|')})-.+$`
+);
+
+async function setCancelDB({
+  applicationCommandName,
+  messageID,
+}: {
+  applicationCommandName: ApplicationCommands;
+  messageID: string;
+}): Promise<
+  | ReturnType<
+      | typeof prisma.buyNFTPoll.update
+      | typeof prisma.floorSweeperPoll.update
+      | typeof prisma.fundAddressPoll.update
+    >
+  | null
+  | undefined
+> {
+  try {
+    switch (applicationCommandName) {
+      case 'BUY':
+        return await prisma.buyNFTPoll.update({
+          data: {isCancelled: true},
+          where: {messageID},
+        });
+
+      case 'FUND':
+        return await prisma.fundAddressPoll.update({
+          data: {isCancelled: true},
+          where: {messageID},
+        });
+
+      case 'SWEEP':
+        return await prisma.floorSweeperPoll.update({
+          data: {isCancelled: true},
+          where: {messageID},
+        });
+
+      default:
+        return undefined;
+    }
+  } catch (error) {
+    console.error(error);
+
+    /**
+     * Handle return if record does not exist
+     *
+     * @see https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
+     */
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error?.code === 'P2025') {
+        return null;
+      }
+    }
+
+    throw new Error(
+      `Something went wrong while saving the transaction data for command type \`${applicationCommandName}\`, \`messageID\` \`${messageID}\`.`
+    );
+  }
+}
+
+function getPollTitle({
+  applicationCommandName,
+  pollEntry,
+}: {
+  applicationCommandName: ApplicationCommands;
+  pollEntry: BuyNFTPoll | FloorSweeperPoll | FundAddressPoll;
+}): string | undefined {
+  try {
+    switch (applicationCommandName) {
+      case 'BUY':
+        return (pollEntry as BuyNFTPoll).name;
+
+      case 'FUND':
+        return (pollEntry as FundAddressPoll).purpose;
+
+      case 'SWEEP':
+        return (pollEntry as FloorSweeperPoll).question;
+
+      default:
+        throw new Error(
+          `Could not find \`APPLICATION_COMMANDS\`: \`${applicationCommandName}\`.`
+        );
+    }
+  } catch (error) {
+    console.error(error);
+
+    throw new Error(
+      `Something went wrong while getting the poll title for application command \`${applicationCommandName}\`.`
+    );
+  }
+}
+
+export async function confirmCancelPollHandler(
+  interaction: Interaction
+): Promise<void> {
+  // If the interaction is not from a button, exit.
+  if (!interaction.isButton()) return;
+
+  const {customId} = interaction;
+
+  // If the pattern of the Discord button's `customId` does not match, exit.
+  if (!CUSTOM_ID_REGEX.test(customId)) return;
+
+  try {
+    const [_, command, messageID] = customId.split('-');
+    const applicationCommandName = command as ApplicationCommands;
+
+    // Store data in database
+    const pollEntry = await setCancelDB({applicationCommandName, messageID});
+
+    if (!pollEntry) {
+      throw new Error(
+        `No poll entry was found for command type \`${applicationCommandName}\`, \`messageID\` \`${messageID}\`.`
+      );
+    }
+
+    const {client} = await getTributeToolsClient();
+
+    // Get channel the poll is in
+    const pollChannel = (await client.channels.fetch(
+      pollEntry.channelID
+    )) as TextChannel;
+
+    // Get poll Discord message
+    const pollMessage = await pollChannel.messages.fetch(messageID);
+
+    const pollTitle = getPollTitle({
+      applicationCommandName,
+      pollEntry,
+    });
+
+    // After replying, delete the original poll
+    await pollMessage.delete();
+
+    // Edit the ephemeral "cancel" interaction
+    await interaction.update({
+      // Remove any action buttons
+      components: [],
+      content: `You've removed the poll, *${pollTitle}*.`,
+    });
+
+    // Reply publicly that the original poll message has been deleted
+    await interaction.followUp({
+      content: `The following poll has been cancelled and removed: *${pollTitle}*.`,
+    });
+
+    // If the poll is already processed, then we need to update the action channel's message.
+    if (pollEntry.processed) {
+      if (!pollEntry.actionMessageID) return;
+
+      const dao = getDaoDataByGuildID(pollEntry.guildID, await getDaos());
+
+      if (!dao) return;
+
+      const resultChannelID =
+        dao?.applications?.TRIBUTE_TOOLS_BOT?.commands[applicationCommandName]
+          .resultChannelID;
+
+      if (!resultChannelID) return;
+
+      // Get channel the action button is in
+      const pollChannel = (await client.channels.fetch(
+        resultChannelID
+      )) as TextChannel;
+
+      // Get poll Discord message
+      const pollMessage = await pollChannel.messages.fetch(
+        pollEntry.actionMessageID
+      );
+
+      const actionStatusEmbed = new MessageEmbed().setDescription(
+        '⛔️ Poll cancelled'
+      );
+
+      // Edit the original action message to show the cancelled status
+      await pollMessage.edit({
+        // Removes button
+        components: [],
+        embeds: [actionStatusEmbed],
+      });
+    }
+  } catch (error) {
+    console.error(error);
+
+    try {
+      await interaction.reply({
+        content: `There was an error while trying to cancel the poll.`,
+        ephemeral: true,
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  }
+}

--- a/src/applications/tribute-tools/handlers/confirmCancelPollHandler.ts
+++ b/src/applications/tribute-tools/handlers/confirmCancelPollHandler.ts
@@ -177,12 +177,12 @@ export async function confirmCancelPollHandler(
       if (!resultChannelID) return;
 
       // Get channel the action button is in
-      const pollChannel = (await client.channels.fetch(
+      const actionChannel = (await client.channels.fetch(
         resultChannelID
       )) as TextChannel;
 
       // Get poll Discord message
-      const pollMessage = await pollChannel.messages.fetch(
+      const actionMessage = await actionChannel.messages.fetch(
         pollEntry.actionMessageID
       );
 
@@ -191,7 +191,7 @@ export async function confirmCancelPollHandler(
       );
 
       // Edit the original action message to show the cancelled status
-      await pollMessage.edit({
+      await actionMessage.edit({
         // Removes button
         components: [],
         embeds: [actionStatusEmbed],

--- a/src/applications/tribute-tools/handlers/confirmCancelPollHandler.ts
+++ b/src/applications/tribute-tools/handlers/confirmCancelPollHandler.ts
@@ -57,8 +57,6 @@ async function setCancelDB({
         return undefined;
     }
   } catch (error) {
-    console.error(error);
-
     /**
      * Handle return if record does not exist
      *
@@ -71,7 +69,7 @@ async function setCancelDB({
     }
 
     throw new Error(
-      `Something went wrong while saving the transaction data for command type \`${applicationCommandName}\`, \`messageID\` \`${messageID}\`.`
+      `Something went wrong while saving the transaction data for command type \`${applicationCommandName}\`, \`messageID\` \`${messageID}\`: ${error}`
     );
   }
 }
@@ -128,7 +126,7 @@ export async function confirmCancelPollHandler(
 
     if (!pollEntry) {
       throw new Error(
-        `No poll entry was found for command type \`${applicationCommandName}\`, \`messageID\` \`${messageID}\`.`
+        `No poll entry was found for command type \`${applicationCommandName}\`, \`messageID\` \`${messageID}\``
       );
     }
 
@@ -165,7 +163,6 @@ export async function confirmCancelPollHandler(
     // If the poll is already processed, then we need to update the action channel's message.
     if (pollEntry.processed) {
       if (!pollEntry.actionMessageID) return;
-
       const dao = getDaoDataByGuildID(pollEntry.guildID, await getDaos());
 
       if (!dao) return;

--- a/src/applications/tribute-tools/handlers/confirmCancelPollHandler.ts
+++ b/src/applications/tribute-tools/handlers/confirmCancelPollHandler.ts
@@ -7,10 +7,10 @@ import {
 import {Interaction, MessageEmbed, TextChannel} from 'discord.js';
 
 import {APPLICATION_COMMANDS} from '../../../config';
-import {getTributeToolsClient} from '..';
-import {prisma} from '../../../singletons';
 import {getDaoDataByGuildID} from '../../../helpers';
 import {getDaos} from '../../../services';
+import {getTributeToolsClient} from '..';
+import {prisma} from '../../../singletons';
 
 type ApplicationCommands = typeof APPLICATION_COMMANDS[number];
 

--- a/src/applications/tribute-tools/handlers/confirmCancelPollHandler.ts
+++ b/src/applications/tribute-tools/handlers/confirmCancelPollHandler.ts
@@ -98,10 +98,8 @@ function getPollTitle({
         );
     }
   } catch (error) {
-    console.error(error);
-
     throw new Error(
-      `Something went wrong while getting the poll title for application command \`${applicationCommandName}\`.`
+      `Something went wrong while getting the poll title for application command \`${applicationCommandName}\`: ${error}`
     );
   }
 }

--- a/src/applications/tribute-tools/handlers/confirmCancelPollHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/confirmCancelPollHandler.unit.test.ts
@@ -1,0 +1,255 @@
+import {FloorSweeperPoll} from '@prisma/client';
+import {CommandInteraction, MessageEmbed} from 'discord.js';
+
+import {
+  BYTES32_FIXTURE,
+  ETH_ADDRESS_FIXTURE,
+  FAKE_DAOS_FIXTURE,
+  GUILD_ID_FIXTURE,
+} from '../../../../test';
+import {confirmCancelPollHandler} from './confirmCancelPollHandler';
+import {prismaMock} from '../../../../test/prismaMock';
+
+describe('confirmCancelPollHandler unit tests', () => {
+  const DEFAULT_DB_ENTRY: FloorSweeperPoll = {
+    actionMessageID: '987654321',
+    channelID: '886976610018934824',
+    contractAddress: ETH_ADDRESS_FIXTURE,
+    createdAt: new Date(0),
+    dateEnd: new Date(10),
+    guildID: GUILD_ID_FIXTURE,
+    id: 1,
+    isCancelled: false,
+    messageID: '123456789',
+    options: {'🇦': 50, '🇧': 100, '🇨': 150, '🚫': 'None'},
+    processed: false,
+    question: 'How much to sweep larvalads fam?',
+    result: 0,
+    txHash: BYTES32_FIXTURE,
+    txStatus: 'success',
+    uuid: 'abc123def456',
+  };
+
+  test('should cancel a poll', async () => {
+    const interactionUpdateSpy = jest.fn();
+    const interactionFollowUpSpy = jest.fn();
+    const pollChannelDeleteSpy = jest.fn();
+
+    const pollChannelMessagesFetchSpy = jest
+      .fn()
+      .mockImplementation(() => ({delete: pollChannelDeleteSpy}));
+
+    const pollChannelFetchSpy = jest.fn().mockImplementationOnce(async () => ({
+      messages: {fetch: pollChannelMessagesFetchSpy},
+    }));
+
+    const FAKE_INTERACTION = {
+      customId: 'confirmCancelPoll-SWEEP-123456789',
+      followUp: interactionFollowUpSpy,
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => true,
+      message: {
+        id: '123456789',
+      },
+      update: interactionUpdateSpy,
+    } as any as CommandInteraction;
+
+    const discordClientSpy = jest
+      .spyOn(await import('../getTributeToolsClient'), 'getTributeToolsClient')
+      .mockImplementation(async () => ({
+        client: {
+          channels: {
+            fetch: pollChannelFetchSpy,
+          },
+        } as any,
+        stop: async () => undefined,
+      }));
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateMock = (
+      prismaMock.floorSweeperPoll as any
+    ).update.mockResolvedValue(DEFAULT_DB_ENTRY);
+
+    await confirmCancelPollHandler(FAKE_INTERACTION);
+
+    expect(dbUpdateMock).toHaveBeenCalledTimes(1);
+
+    expect(dbUpdateMock).toHaveBeenNthCalledWith(1, {
+      data: {
+        isCancelled: true,
+      },
+      where: {
+        messageID: '123456789',
+      },
+    });
+
+    expect(pollChannelFetchSpy).toHaveBeenCalledTimes(1);
+
+    expect(pollChannelFetchSpy).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_DB_ENTRY.channelID
+    );
+
+    expect(pollChannelMessagesFetchSpy).toHaveBeenCalledTimes(1);
+
+    expect(pollChannelMessagesFetchSpy).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_DB_ENTRY.messageID
+    );
+
+    expect(pollChannelDeleteSpy).toHaveBeenCalledTimes(1);
+    expect(pollChannelDeleteSpy).toHaveBeenNthCalledWith(1);
+
+    expect(interactionUpdateSpy).toHaveBeenCalledTimes(1);
+
+    expect(interactionUpdateSpy).toHaveBeenNthCalledWith(1, {
+      components: [],
+      content: `You've removed the poll, *How much to sweep larvalads fam?*.`,
+    });
+
+    expect(interactionFollowUpSpy).toHaveBeenCalledTimes(1);
+
+    expect(interactionFollowUpSpy).toHaveBeenNthCalledWith(1, {
+      content:
+        'The following poll has been cancelled and removed: *How much to sweep larvalads fam?*.',
+    });
+
+    // Cleanup
+
+    dbUpdateMock.mockRestore();
+    discordClientSpy.mockRestore();
+  });
+
+  test('should cancel an already processed poll', async () => {
+    const interactionUpdateSpy = jest.fn();
+    const interactionFollowUpSpy = jest.fn();
+    const pollChannelDeleteSpy = jest.fn();
+    const actionChannelEditSpy = jest.fn();
+
+    const pollChannelMessagesFetchSpy = jest.fn().mockImplementation(() => ({
+      delete: pollChannelDeleteSpy,
+    }));
+
+    const actionChannelMessagesFetchSpy = jest.fn().mockImplementation(() => ({
+      edit: actionChannelEditSpy,
+    }));
+
+    const channelFetchSpy = jest
+      .fn()
+      .mockImplementationOnce(async () => ({
+        messages: {fetch: pollChannelMessagesFetchSpy},
+      }))
+      .mockImplementationOnce(async () => ({
+        messages: {fetch: actionChannelMessagesFetchSpy},
+      }));
+
+    const FAKE_INTERACTION = {
+      customId: 'confirmCancelPoll-SWEEP-123456789',
+      followUp: interactionFollowUpSpy,
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => true,
+      message: {
+        id: '123456789',
+      },
+      update: interactionUpdateSpy,
+    } as any as CommandInteraction;
+
+    const discordClientSpy = jest
+      .spyOn(await import('../getTributeToolsClient'), 'getTributeToolsClient')
+      .mockImplementation(async () => ({
+        client: {
+          channels: {
+            fetch: channelFetchSpy,
+          },
+        } as any,
+        stop: async () => undefined,
+      }));
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateMock = (
+      prismaMock.floorSweeperPoll as any
+    ).update.mockResolvedValue({...DEFAULT_DB_ENTRY, processed: true});
+
+    const getDaosSpy = jest
+      .spyOn(await import('../../../services/dao/getDaos'), 'getDaos')
+      .mockImplementation(async () => FAKE_DAOS_FIXTURE);
+
+    await confirmCancelPollHandler(FAKE_INTERACTION);
+
+    expect(dbUpdateMock).toHaveBeenCalledTimes(1);
+
+    expect(dbUpdateMock).toHaveBeenNthCalledWith(1, {
+      data: {
+        isCancelled: true,
+      },
+      where: {
+        messageID: '123456789',
+      },
+    });
+
+    expect(channelFetchSpy).toHaveBeenCalledTimes(2);
+
+    expect(channelFetchSpy).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_DB_ENTRY.channelID
+    );
+
+    expect(channelFetchSpy).toHaveBeenNthCalledWith(
+      2,
+      FAKE_DAOS_FIXTURE.test.applications?.TRIBUTE_TOOLS_BOT?.commands.SWEEP
+        .resultChannelID
+    );
+
+    expect(pollChannelMessagesFetchSpy).toHaveBeenCalledTimes(1);
+    expect(pollChannelMessagesFetchSpy).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_DB_ENTRY.messageID
+    );
+
+    expect(actionChannelMessagesFetchSpy).toHaveBeenCalledTimes(1);
+
+    expect(actionChannelMessagesFetchSpy).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_DB_ENTRY.actionMessageID
+    );
+
+    expect(pollChannelDeleteSpy).toHaveBeenCalledTimes(1);
+    expect(pollChannelDeleteSpy).toHaveBeenNthCalledWith(1);
+
+    expect(interactionUpdateSpy).toHaveBeenCalledTimes(1);
+
+    expect(interactionUpdateSpy).toHaveBeenNthCalledWith(1, {
+      components: [],
+      content: `You've removed the poll, *How much to sweep larvalads fam?*.`,
+    });
+
+    expect(interactionFollowUpSpy).toHaveBeenCalledTimes(1);
+
+    expect(interactionFollowUpSpy).toHaveBeenNthCalledWith(1, {
+      content:
+        'The following poll has been cancelled and removed: *How much to sweep larvalads fam?*.',
+    });
+
+    expect(actionChannelEditSpy).toHaveBeenCalledTimes(1);
+
+    expect(actionChannelEditSpy).toHaveBeenNthCalledWith(1, {
+      components: [],
+      embeds: [new MessageEmbed().setDescription('⛔️ Poll cancelled')],
+    });
+
+    // Cleanup
+
+    channelFetchSpy.mockRestore();
+    dbUpdateMock.mockRestore();
+    discordClientSpy.mockRestore();
+    getDaosSpy.mockRestore();
+  });
+});

--- a/src/applications/tribute-tools/handlers/confirmCancelPollHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/confirmCancelPollHandler.unit.test.ts
@@ -1,5 +1,5 @@
-import {FloorSweeperPoll} from '@prisma/client';
 import {CommandInteraction, MessageEmbed} from 'discord.js';
+import {FloorSweeperPoll, Prisma} from '@prisma/client';
 
 import {
   BYTES32_FIXTURE,
@@ -238,6 +238,7 @@ describe('confirmCancelPollHandler unit tests', () => {
         'The following poll has been cancelled and removed: *How much to sweep larvalads fam?*.',
     });
 
+    expect(getDaosSpy).toHaveBeenCalledTimes(1);
     expect(actionChannelEditSpy).toHaveBeenCalledTimes(1);
 
     expect(actionChannelEditSpy).toHaveBeenNthCalledWith(1, {
@@ -247,9 +248,474 @@ describe('confirmCancelPollHandler unit tests', () => {
 
     // Cleanup
 
-    channelFetchSpy.mockRestore();
     dbUpdateMock.mockRestore();
     discordClientSpy.mockRestore();
     getDaosSpy.mockRestore();
+  });
+
+  test('should exit if `interaction` is not a button', async () => {
+    const FAKE_INTERACTION = {
+      customId: 'confirmCancelPoll-SWEEP-123456789',
+      guildId: GUILD_ID_FIXTURE,
+      // Not a button
+      isButton: () => false,
+      message: {
+        id: '123456789',
+      },
+    } as any as CommandInteraction;
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateMock = (
+      prismaMock.floorSweeperPoll as any
+    ).update.mockResolvedValue(DEFAULT_DB_ENTRY);
+
+    await confirmCancelPollHandler(FAKE_INTERACTION);
+
+    expect(dbUpdateMock).toHaveBeenCalledTimes(0);
+
+    // Cleanup
+
+    dbUpdateMock.mockRestore();
+  });
+
+  test('should exit if `customId` does not match `RegExp`', async () => {
+    const FAKE_INTERACTION = {
+      // Does not match
+      customId: 'confirmCancelPoll-BAD-123456789',
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => true,
+      message: {
+        id: '123456789',
+      },
+    } as any as CommandInteraction;
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateMock = (
+      prismaMock.floorSweeperPoll as any
+    ).update.mockResolvedValue(DEFAULT_DB_ENTRY);
+
+    await confirmCancelPollHandler(FAKE_INTERACTION);
+
+    expect(dbUpdateMock).toHaveBeenCalledTimes(0);
+
+    // Cleanup
+
+    dbUpdateMock.mockRestore();
+  });
+
+  test('should exit if `actionMessageID` is not found on DB entry', async () => {
+    const interactionUpdateSpy = jest.fn();
+    const interactionFollowUpSpy = jest.fn();
+    const pollChannelDeleteSpy = jest.fn();
+    const actionChannelEditSpy = jest.fn();
+
+    const pollChannelMessagesFetchSpy = jest.fn().mockImplementation(() => ({
+      delete: pollChannelDeleteSpy,
+    }));
+
+    const actionChannelMessagesFetchSpy = jest.fn().mockImplementation(() => ({
+      edit: actionChannelEditSpy,
+    }));
+
+    const channelFetchSpy = jest
+      .fn()
+      .mockImplementationOnce(async () => ({
+        messages: {fetch: pollChannelMessagesFetchSpy},
+      }))
+      .mockImplementationOnce(async () => ({
+        messages: {fetch: actionChannelMessagesFetchSpy},
+      }));
+
+    const FAKE_INTERACTION = {
+      customId: 'confirmCancelPoll-SWEEP-123456789',
+      followUp: interactionFollowUpSpy,
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => true,
+      message: {
+        id: '123456789',
+      },
+      update: interactionUpdateSpy,
+    } as any as CommandInteraction;
+
+    const discordClientSpy = jest
+      .spyOn(await import('../getTributeToolsClient'), 'getTributeToolsClient')
+      .mockImplementation(async () => ({
+        client: {
+          channels: {
+            fetch: channelFetchSpy,
+          },
+        } as any,
+        stop: async () => undefined,
+      }));
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateMock = (
+      prismaMock.floorSweeperPoll as any
+    ).update.mockResolvedValue({
+      ...DEFAULT_DB_ENTRY,
+      actionMessageID: null,
+      processed: true,
+    });
+
+    await confirmCancelPollHandler(FAKE_INTERACTION);
+
+    expect(dbUpdateMock).toHaveBeenCalledTimes(1);
+
+    expect(dbUpdateMock).toHaveBeenNthCalledWith(1, {
+      data: {
+        isCancelled: true,
+      },
+      where: {
+        messageID: '123456789',
+      },
+    });
+
+    expect(channelFetchSpy).toHaveBeenCalledTimes(1);
+
+    expect(channelFetchSpy).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_DB_ENTRY.channelID
+    );
+
+    expect(pollChannelMessagesFetchSpy).toHaveBeenCalledTimes(1);
+    expect(pollChannelMessagesFetchSpy).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_DB_ENTRY.messageID
+    );
+
+    expect(actionChannelMessagesFetchSpy).toHaveBeenCalledTimes(0);
+
+    expect(pollChannelDeleteSpy).toHaveBeenCalledTimes(1);
+    expect(pollChannelDeleteSpy).toHaveBeenNthCalledWith(1);
+
+    expect(interactionUpdateSpy).toHaveBeenCalledTimes(1);
+
+    expect(interactionUpdateSpy).toHaveBeenNthCalledWith(1, {
+      components: [],
+      content: `You've removed the poll, *How much to sweep larvalads fam?*.`,
+    });
+
+    expect(interactionFollowUpSpy).toHaveBeenCalledTimes(1);
+
+    expect(interactionFollowUpSpy).toHaveBeenNthCalledWith(1, {
+      content:
+        'The following poll has been cancelled and removed: *How much to sweep larvalads fam?*.',
+    });
+
+    // Assert "edit" code block exited early
+    expect(actionChannelEditSpy).toHaveBeenCalledTimes(0);
+
+    // Cleanup
+
+    dbUpdateMock.mockRestore();
+    discordClientSpy.mockRestore();
+  });
+
+  test('should exit if DAO is not found', async () => {
+    const interactionUpdateSpy = jest.fn();
+    const interactionFollowUpSpy = jest.fn();
+    const pollChannelDeleteSpy = jest.fn();
+    const actionChannelEditSpy = jest.fn();
+
+    const pollChannelMessagesFetchSpy = jest.fn().mockImplementation(() => ({
+      delete: pollChannelDeleteSpy,
+    }));
+
+    const actionChannelMessagesFetchSpy = jest.fn().mockImplementation(() => ({
+      edit: actionChannelEditSpy,
+    }));
+
+    const channelFetchSpy = jest
+      .fn()
+      .mockImplementationOnce(async () => ({
+        messages: {fetch: pollChannelMessagesFetchSpy},
+      }))
+      .mockImplementationOnce(async () => ({
+        messages: {fetch: actionChannelMessagesFetchSpy},
+      }));
+
+    const FAKE_INTERACTION = {
+      customId: 'confirmCancelPoll-SWEEP-123456789',
+      followUp: interactionFollowUpSpy,
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => true,
+      message: {
+        id: '123456789',
+      },
+      update: interactionUpdateSpy,
+    } as any as CommandInteraction;
+
+    const discordClientSpy = jest
+      .spyOn(await import('../getTributeToolsClient'), 'getTributeToolsClient')
+      .mockImplementation(async () => ({
+        client: {
+          channels: {
+            fetch: channelFetchSpy,
+          },
+        } as any,
+        stop: async () => undefined,
+      }));
+
+    const getDaosSpy = jest
+      .spyOn(await import('../../../services/dao/getDaos'), 'getDaos')
+      .mockImplementation(async () => undefined);
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateMock = (
+      prismaMock.floorSweeperPoll as any
+    ).update.mockResolvedValue({...DEFAULT_DB_ENTRY, processed: true});
+
+    await confirmCancelPollHandler(FAKE_INTERACTION);
+
+    expect(dbUpdateMock).toHaveBeenCalledTimes(1);
+
+    expect(dbUpdateMock).toHaveBeenNthCalledWith(1, {
+      data: {
+        isCancelled: true,
+      },
+      where: {
+        messageID: '123456789',
+      },
+    });
+
+    expect(channelFetchSpy).toHaveBeenCalledTimes(1);
+
+    expect(channelFetchSpy).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_DB_ENTRY.channelID
+    );
+
+    expect(pollChannelMessagesFetchSpy).toHaveBeenCalledTimes(1);
+    expect(pollChannelMessagesFetchSpy).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_DB_ENTRY.messageID
+    );
+
+    expect(actionChannelMessagesFetchSpy).toHaveBeenCalledTimes(0);
+
+    expect(pollChannelDeleteSpy).toHaveBeenCalledTimes(1);
+    expect(pollChannelDeleteSpy).toHaveBeenNthCalledWith(1);
+
+    expect(interactionUpdateSpy).toHaveBeenCalledTimes(1);
+
+    expect(interactionUpdateSpy).toHaveBeenNthCalledWith(1, {
+      components: [],
+      content: `You've removed the poll, *How much to sweep larvalads fam?*.`,
+    });
+
+    expect(interactionFollowUpSpy).toHaveBeenCalledTimes(1);
+
+    expect(interactionFollowUpSpy).toHaveBeenNthCalledWith(1, {
+      content:
+        'The following poll has been cancelled and removed: *How much to sweep larvalads fam?*.',
+    });
+
+    // Assert "edit" code block exited early
+    expect(getDaosSpy).toHaveBeenCalledTimes(1);
+    expect(actionChannelEditSpy).toHaveBeenCalledTimes(0);
+
+    // Cleanup
+
+    dbUpdateMock.mockRestore();
+    discordClientSpy.mockRestore();
+    getDaosSpy.mockRestore();
+  });
+
+  test('should handle error if DB return data is `undefined`', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation((e) => e);
+
+    const interactionReplySpy = jest.fn();
+
+    const FAKE_INTERACTION = {
+      customId: 'confirmCancelPoll-SWEEP-123456789',
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => true,
+      message: {
+        id: '123456789',
+      },
+      reply: interactionReplySpy,
+    } as any as CommandInteraction;
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateMock = (
+      prismaMock.floorSweeperPoll as any
+    ).update.mockResolvedValue(undefined);
+
+    await confirmCancelPollHandler(FAKE_INTERACTION);
+
+    expect(dbUpdateMock).toHaveBeenCalledTimes(1);
+
+    expect(dbUpdateMock).toHaveBeenNthCalledWith(1, {
+      data: {
+        isCancelled: true,
+      },
+      where: {
+        messageID: '123456789',
+      },
+    });
+
+    expect(interactionReplySpy).toHaveBeenCalledTimes(1);
+
+    expect(interactionReplySpy).toHaveBeenNthCalledWith(1, {
+      content: 'There was an error while trying to cancel the poll.',
+      ephemeral: true,
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    expect(consoleErrorSpy.mock.calls[0][0]?.message).toMatch(
+      /No poll entry was found for command type `SWEEP`, `messageID` `123456789`/i
+    );
+
+    // Cleanup
+
+    consoleErrorSpy.mockRestore();
+    dbUpdateMock.mockRestore();
+  });
+
+  test('should handle Prisma error code `P2025` if DB entry is not found', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation((e) => e);
+
+    const interactionReplySpy = jest.fn();
+
+    const FAKE_INTERACTION = {
+      customId: 'confirmCancelPoll-SWEEP-123456789',
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => true,
+      message: {
+        id: '123456789',
+      },
+      reply: interactionReplySpy,
+    } as any as CommandInteraction;
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateMock = (
+      prismaMock.floorSweeperPoll as any
+    ).update.mockImplementation(async () => {
+      throw new Prisma.PrismaClientKnownRequestError(
+        'Prisma error',
+        'P2025',
+        '1.0'
+      );
+    });
+
+    await confirmCancelPollHandler(FAKE_INTERACTION);
+
+    expect(dbUpdateMock).toHaveBeenCalledTimes(1);
+
+    expect(dbUpdateMock).toHaveBeenNthCalledWith(1, {
+      data: {
+        isCancelled: true,
+      },
+      where: {
+        messageID: '123456789',
+      },
+    });
+
+    expect(interactionReplySpy).toHaveBeenCalledTimes(1);
+
+    expect(interactionReplySpy).toHaveBeenNthCalledWith(1, {
+      content: 'There was an error while trying to cancel the poll.',
+      ephemeral: true,
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    expect(consoleErrorSpy.mock.calls[0][0]?.message).toMatch(
+      /No poll entry was found for command type `SWEEP`, `messageID` `123456789`/i
+    );
+
+    // Cleanup
+
+    consoleErrorSpy.mockRestore();
+    dbUpdateMock.mockRestore();
+  });
+
+  test('should handle error if something goes wrong while updating the DB data', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation((e) => e);
+
+    const interactionReplySpy = jest.fn();
+
+    const FAKE_INTERACTION = {
+      customId: 'confirmCancelPoll-SWEEP-123456789',
+      guildId: GUILD_ID_FIXTURE,
+      isButton: () => true,
+      message: {
+        id: '123456789',
+      },
+      reply: interactionReplySpy,
+    } as any as CommandInteraction;
+
+    /**
+     * Mock db update
+     *
+     * @todo fix types
+     */
+    const dbUpdateMock = (
+      prismaMock.floorSweeperPoll as any
+    ).update.mockImplementation(async () => {
+      throw new Error('Some bad DB error.');
+    });
+
+    await confirmCancelPollHandler(FAKE_INTERACTION);
+
+    expect(dbUpdateMock).toHaveBeenCalledTimes(1);
+
+    expect(dbUpdateMock).toHaveBeenNthCalledWith(1, {
+      data: {
+        isCancelled: true,
+      },
+      where: {
+        messageID: '123456789',
+      },
+    });
+
+    expect(interactionReplySpy).toHaveBeenCalledTimes(1);
+
+    expect(interactionReplySpy).toHaveBeenNthCalledWith(1, {
+      content: 'There was an error while trying to cancel the poll.',
+      ephemeral: true,
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    expect(consoleErrorSpy.mock.calls[0][0]?.message).toMatch(
+      /Something went wrong while saving the transaction data for command type `SWEEP`, `messageID` `123456789`: Error: Some bad DB error/i
+    );
+
+    // Cleanup
+
+    consoleErrorSpy.mockRestore();
+    dbUpdateMock.mockRestore();
   });
 });

--- a/src/applications/tribute-tools/handlers/index.ts
+++ b/src/applications/tribute-tools/handlers/index.ts
@@ -1,5 +1,6 @@
 export * from './buy';
 export * from './cancelPollHandler';
+export * from './confirmCancelPollHandler';
 export * from './fund';
 export * from './interactionExecuteHandler';
 export * from './notifyPollTxStatus';

--- a/src/applications/tribute-tools/handlers/index.ts
+++ b/src/applications/tribute-tools/handlers/index.ts
@@ -1,5 +1,6 @@
 export * from './buy';
-export * from './interactionExecuteHandler';
+export * from './cancelPollHandler';
 export * from './fund';
+export * from './interactionExecuteHandler';
 export * from './notifyPollTxStatus';
 export * from './sweep';

--- a/src/applications/tribute-tools/handlers/notifyPollTxStatus.ts
+++ b/src/applications/tribute-tools/handlers/notifyPollTxStatus.ts
@@ -111,6 +111,7 @@ export async function notifyPollTxStatus({
     const name = getName({dbEntry, type});
     const description = getStatus({name, status});
     const etherscanURL: string = `https://etherscan.io/tx/${txHash}`;
+    const txSucceeded: boolean = status === TributeToolsWebhookTxStatus.SUCCESS;
 
     const pollStatusEmbed = new MessageEmbed()
       .setTitle(title)
@@ -122,11 +123,15 @@ export async function notifyPollTxStatus({
       embeds: [pollStatusEmbed],
     });
 
+    // Edit the poll message to remove the cancel button
+    if (txSucceeded) {
+      await pollMessage.edit({components: []});
+    }
+
     if (!actionMessageID) {
       throw new Error(`No \`actionMessageID\` was found.`);
     }
 
-    const txSucceeded: boolean = status === TributeToolsWebhookTxStatus.SUCCESS;
     const dao = getDaoDataByGuildID(guildID, await getDaos());
     const command = getCommand(type);
 

--- a/src/applications/tribute-tools/handlers/notifyPollTxStatus.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/notifyPollTxStatus.unit.test.ts
@@ -22,31 +22,33 @@ import {notifyPollTxStatus} from './notifyPollTxStatus';
 
 describe('notifyPollTxStatus unit tests', () => {
   const SWEEP_DB_ENTRY: FloorSweeperPoll = {
-    id: 1,
-    uuid: UUID_FIXTURE,
-    createdAt: new Date(0),
-    question: 'How much in punks should we sweep?',
+    actionMessageID: '987654321',
+    channelID: '123456789',
     contractAddress: ETH_ADDRESS_FIXTURE,
+    createdAt: new Date(0),
     dateEnd: new Date(10000),
+    guildID: GUILD_ID_FIXTURE,
+    id: 1,
+    isCancelled: false,
+    messageID: '567890123',
     options: {'🇦': 50, '🇧': 100, '🇨': 150, '🚫': 'None'},
     processed: true,
+    question: 'How much in punks should we sweep?',
     result: 100,
-    guildID: GUILD_ID_FIXTURE,
-    channelID: '123456789',
-    messageID: '567890123',
-    actionMessageID: '987654321',
-    txStatus: TributeToolsTxStatus.success,
     txHash: BYTES32_FIXTURE,
+    txStatus: TributeToolsTxStatus.success,
+    uuid: UUID_FIXTURE,
   };
 
   const BUY_DB_ENTRY: BuyNFTPoll = {
-    amountWEI: new Prisma.Decimal('2200000000000000000'),
     actionMessageID: '987654321',
+    amountWEI: new Prisma.Decimal('2200000000000000000'),
     channelID: '123456789',
     contractAddress: ETH_ADDRESS_FIXTURE,
     createdAt: new Date(0),
     guildID: GUILD_ID_FIXTURE,
     id: 1,
+    isCancelled: false,
     messageID: '567890123',
     name: 'Should we buy Dexter Funky Xavier?',
     processed: true,
@@ -66,6 +68,7 @@ describe('notifyPollTxStatus unit tests', () => {
     createdAt: new Date(0),
     guildID: GUILD_ID_FIXTURE,
     id: 1,
+    isCancelled: false,
     messageID: '567890123',
     processed: true,
     purpose: 'Seed round for Tribute Labs',
@@ -136,7 +139,7 @@ describe('notifyPollTxStatus unit tests', () => {
     expect(channelsFetchSpy).toHaveBeenCalledTimes(2);
     expect(messagesFetchSpy).toHaveBeenCalledTimes(2);
     expect(messageReplySpy).toHaveBeenCalledTimes(1);
-    expect(messageEditSpy).toHaveBeenCalledTimes(1);
+    expect(messageEditSpy).toHaveBeenCalledTimes(2);
     expect(channelsFetchSpy).toHaveBeenNthCalledWith(1, '123456789');
     expect(channelsFetchSpy).toHaveBeenNthCalledWith(2, '123123123123123123');
     expect(messagesFetchSpy).toHaveBeenNthCalledWith(1, '567890123');
@@ -154,6 +157,10 @@ describe('notifyPollTxStatus unit tests', () => {
     });
 
     expect(messageEditSpy).toHaveBeenNthCalledWith(1, {
+      components: [],
+    });
+
+    expect(messageEditSpy).toHaveBeenNthCalledWith(2, {
       components: [],
       embeds: [
         new MessageEmbed().setDescription(

--- a/src/applications/tribute-tools/main.ts
+++ b/src/applications/tribute-tools/main.ts
@@ -6,6 +6,7 @@ import {
   buyPollReactionHandler,
   buyPollRemoveReactionHandler,
   cancelPollHandler,
+  confirmCancelPollHandler,
   fundPollReactionHandler,
   fundPollRemoveReactionHandler,
   interactionExecuteHandler,
@@ -57,6 +58,7 @@ export async function tributeToolsBot(): Promise<
     client.on('interactionCreate', (interaction) => {
       interactionExecuteHandler({commands, interaction});
       cancelPollHandler(interaction);
+      confirmCancelPollHandler(interaction);
     });
 
     // Listen to reactions on messages, and possibly handle.

--- a/src/applications/tribute-tools/main.ts
+++ b/src/applications/tribute-tools/main.ts
@@ -14,6 +14,7 @@ import {deployCommands, destroyClientHandler, getCommands} from '../helpers';
 import {getEnv} from '../../helpers';
 import {getTributeToolsClient} from '.';
 import {TRIBUTE_TOOLS_BOT_ID} from '../../config';
+import {cancelPollHandler} from './handlers/cancelPollHandler';
 
 export async function tributeToolsBot(): Promise<
   ApplicationReturn | undefined
@@ -55,6 +56,7 @@ export async function tributeToolsBot(): Promise<
     // Listen for interactions and possibly run commands
     client.on('interactionCreate', (interaction) => {
       interactionExecuteHandler({commands, interaction});
+      cancelPollHandler(interaction);
     });
 
     // Listen to reactions on messages, and possibly handle.

--- a/src/applications/tribute-tools/main.ts
+++ b/src/applications/tribute-tools/main.ts
@@ -5,16 +5,16 @@ import {
 import {
   buyPollReactionHandler,
   buyPollRemoveReactionHandler,
+  cancelPollHandler,
   fundPollReactionHandler,
   fundPollRemoveReactionHandler,
   interactionExecuteHandler,
 } from './handlers';
 import {ApplicationReturn} from '../types';
-import {deployCommands, destroyClientHandler, getCommands} from '../helpers';
+import {deployCommands, getCommands} from '../helpers';
 import {getEnv} from '../../helpers';
 import {getTributeToolsClient} from '.';
 import {TRIBUTE_TOOLS_BOT_ID} from '../../config';
-import {cancelPollHandler} from './handlers/cancelPollHandler';
 
 export async function tributeToolsBot(): Promise<
   ApplicationReturn | undefined

--- a/src/applications/tribute-tools/main.unit.test.ts
+++ b/src/applications/tribute-tools/main.unit.test.ts
@@ -85,10 +85,18 @@ describe('tribute-tools/main unit tests', () => {
   });
 
   test('should call `interactionCreate` handlers', async () => {
+    const DEFAULT_INTERACTION = {interactionTest: 'test'};
+
     const discord = await import('discord.js');
 
     const interactionExecuteHandler = await import(
       './handlers/interactionExecuteHandler'
+    );
+
+    const cancelPollHandler = await import('./handlers/cancelPollHandler');
+
+    const confirmCancelPollHandler = await import(
+      './handlers/confirmCancelPollHandler'
     );
 
     const loginSpy = jest
@@ -99,8 +107,15 @@ describe('tribute-tools/main unit tests', () => {
       .spyOn(interactionExecuteHandler, 'interactionExecuteHandler')
       .mockImplementation(() => null as any);
 
-    const {tributeToolsBot} = await import('../tribute-tools/main');
+    const cancelPollHandlerSpy = jest
+      .spyOn(cancelPollHandler, 'cancelPollHandler')
+      .mockImplementation(() => null as any);
 
+    const confirmCancelPollHandlerSpy = jest
+      .spyOn(confirmCancelPollHandler, 'confirmCancelPollHandler')
+      .mockImplementation(() => null as any);
+
+    const {tributeToolsBot} = await import('../tribute-tools/main');
     const deployCommands = await import('../helpers/deployCommands');
 
     const deployCommandsSpy = jest
@@ -118,8 +133,16 @@ describe('tribute-tools/main unit tests', () => {
 
     expect(interactionExecuteHandlerSpy).toHaveBeenCalledWith({
       commands: await getCommands(async () => await import('./commands')),
-      interaction: {interactionTest: 'test'},
+      interaction: DEFAULT_INTERACTION,
     });
+
+    expect(cancelPollHandlerSpy).toHaveBeenCalledTimes(1);
+    expect(cancelPollHandlerSpy).toHaveBeenCalledWith(DEFAULT_INTERACTION);
+    expect(confirmCancelPollHandlerSpy).toHaveBeenCalledTimes(1);
+
+    expect(confirmCancelPollHandlerSpy).toHaveBeenCalledWith(
+      DEFAULT_INTERACTION
+    );
 
     // Cleanup
 

--- a/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.ts
+++ b/src/http-api/middleware/tributeTools/tributeToolsTxWebhook.ts
@@ -54,9 +54,9 @@ async function storeTxData(
   payload: TributeToolsWebhookPayload
 ): Promise<
   | ReturnType<
+      | typeof prisma.buyNFTPoll.update
       | typeof prisma.floorSweeperPoll.update
       | typeof prisma.fundAddressPoll.update
-      | typeof prisma.buyNFTPoll.update
     >
   | null
   | undefined


### PR DESCRIPTION
Fixes #93 

🥳 **Adds**

- DB migration for adding `isCancelled` to `buy_nft_poll`, `floor_sweeper_poll`, `fund_address_poll`
- Adds `Cancel poll` button to reply from `/buy`, `/fund`, `/sweep`
- `cancelPollHandler` for handling the click of the `Cancel poll` button
- `confirmCancelPollHandler` for handling confirmation of cancelling the poll

✨ **Updates**

- `notifyPollTxStatus` to remove the `Cancel poll` button if the tx status is successful.
- `main` to run the cancel poll handlers


