### PR TITLE
Makes `GEM_API_KEY` optional

### DIFF
--- a/src/config/common.ts
+++ b/src/config/common.ts
@@ -39,11 +39,21 @@ export const ENVIRONMENT_VARIABLE_KEYS = [
   'DATABASE_URL',
   'DEBUG',
   'ETH_NETWORK_NAME',
-  'GEM_API_KEY',
   'NODE_ENV',
   'POSTGRES_DB',
   'POSTGRES_PASSWORD',
   'POSTGRES_USER',
+] as const;
+
+/**
+ * Environment variable keys used in the app,
+ * but are optional.
+ */
+export const ENVIRONMENT_VARIABLE_KEYS_OPTIONAL = [
+  /**
+   * Used in `applications/tribute-tools`.
+   */
+  'GEM_API_KEY',
 ] as const;
 
 /**

--- a/src/helpers/envCheck.ts
+++ b/src/helpers/envCheck.ts
@@ -7,31 +7,21 @@ import {getEnv} from './getEnv';
  * Checks whether all requested environment variables
  * are set, logs the status, and returns `boolean`.
  *
- * @param {string} `envs` - Optional array of environment variable keys to check.
- *   If not provided `enum EnvironmentVariables` will be used.
- *
  * @returns `boolean`
  */
-export function envCheck(
-  envKeys: typeof ENVIRONMENT_VARIABLE_KEYS = ENVIRONMENT_VARIABLE_KEYS,
-  options: {noLog?: boolean} = {}
-): boolean {
-  const {noLog} = options;
+export function envCheck(): boolean {
+  const areAllSet: boolean = ENVIRONMENT_VARIABLE_KEYS.map((name) => {
+    // Do not log the environment variable value!
+    const value = getEnv(name);
 
-  const areAllSet: boolean = envKeys
-    .map((name) => {
-      // Do not log the environment variable value!
-      const value = getEnv(name);
+    if (!value) {
+      console.warn(`⚠️  Missing required environment variable for ${name}.`);
+    }
 
-      if (!value && !noLog) {
-        console.warn(`⚠️  Missing required environment variable for ${name}.`);
-      }
+    return value;
+  }).every((v) => v);
 
-      return value;
-    })
-    .every((v) => v);
-
-  if (areAllSet && !noLog) {
+  if (areAllSet) {
     console.log('✔ All required environment variables are set.');
   }
 

--- a/src/helpers/envCheck.ts
+++ b/src/helpers/envCheck.ts
@@ -13,9 +13,7 @@ import {getEnv} from './getEnv';
  * @returns `boolean`
  */
 export function envCheck(
-  envKeys: Partial<
-    typeof ENVIRONMENT_VARIABLE_KEYS
-  > = ENVIRONMENT_VARIABLE_KEYS,
+  envKeys: typeof ENVIRONMENT_VARIABLE_KEYS = ENVIRONMENT_VARIABLE_KEYS,
   options: {noLog?: boolean} = {}
 ): boolean {
   const {noLog} = options;

--- a/src/helpers/envCheck.unit.test.ts
+++ b/src/helpers/envCheck.unit.test.ts
@@ -1,37 +1,40 @@
 import {envCheck} from './envCheck';
 
 describe('envCheck unit tests', () => {
-  const testOptions = {noLog: true};
-
   test('should return `true` if all environment variables are set', () => {
-    process.env.ALCHEMY_API_KEY = 'abc123test';
-    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
-    process.env.POSTGRES_DB = 'test';
-    process.env.POSTGRES_PASSWORD = 'test';
-    process.env.POSTGRES_USER = 'test';
+    const spy = jest.spyOn(console, 'log').mockImplementation((m) => m);
 
-    // Using default args; no logging
-    expect(envCheck(undefined, testOptions)).toBe(true);
+    // Uses `.env.test`
+    expect(envCheck()).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
 
-    process.env.SOME_VAR = 'test';
+    expect(spy.mock.calls[0][0]).toMatch(
+      /✔ All required environment variables are set\./i
+    );
 
-    // Using supplied args; no logging
-    expect(envCheck(['ALCHEMY_API_KEY'], testOptions)).toBe(true);
+    // Cleanup
 
-    // Reset env
-    delete process.env.ALCHEMY_API_KEY;
-    delete process.env.DATABASE_URL;
-    delete process.env.POSTGRES_DB;
-    delete process.env.POSTGRES_PASSWORD;
-    delete process.env.POSTGRES_USER;
-    delete process.env.SOME_VAR;
+    spy.mockRestore();
   });
 
-  test('should return `false` if some, or all, environment are not set', () => {
-    // Using default args; no logging
-    expect(envCheck(undefined, testOptions)).toBe(false);
+  test('should return `false` if some environment variables are not set', () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation((w) => w);
 
-    // Using supplied args; no logging
-    expect(envCheck(['ALCHEMY_API_KEY'], testOptions)).toBe(false);
+    const original = process.env.POSTGRES_USER;
+
+    process.env.POSTGRES_USER = undefined;
+
+    // Using default args; no logging
+    expect(envCheck()).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    expect(spy.mock.calls[0][0]).toMatch(
+      /⚠️  Missing required environment variable for POSTGRES_USER\./i
+    );
+
+    // Cleanup
+
+    process.env.POSTGRES_USER = original;
+    spy.mockRestore();
   });
 });

--- a/src/helpers/getEnv.ts
+++ b/src/helpers/getEnv.ts
@@ -1,11 +1,13 @@
 import {
   ENVIRONMENT_VARIABLE_KEYS,
   ENVIRONMENT_VARIABLE_KEYS_BOT_TOKENS,
+  ENVIRONMENT_VARIABLE_KEYS_OPTIONAL,
 } from '../config';
 
-type AvailableEnv = Partial<
-  typeof ENVIRONMENT_VARIABLE_KEYS | typeof ENVIRONMENT_VARIABLE_KEYS_BOT_TOKENS
->[number];
+type AvailableEnv =
+  | typeof ENVIRONMENT_VARIABLE_KEYS[number]
+  | typeof ENVIRONMENT_VARIABLE_KEYS_BOT_TOKENS[number]
+  | typeof ENVIRONMENT_VARIABLE_KEYS_OPTIONAL[number];
 
 /**
  * Returns the current environment variable value.


### PR DESCRIPTION

🧹 **Chores done**

- Empty `GEM_API_KEY` does not cause the startup env check to warn
- Improves types on `envCheck`, `getEnv` functions
- Slight refactor on `getEnv` and improves tests