### PR TITLE
Adds `workflow_dispatch` to run GH Action manually if needed

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   test-coverage:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -3,11 +3,12 @@ name: GKE Development Deployment
 on:
   push:
     tags-ignore:
-      - 'v*'
+      - "v*"
     branches:
       - main
     paths-ignore:
       - ".github/workflows/deploy-prod.yml"
+  workflow_dispatch:
 
 env:
   ## Required Env Vars
@@ -24,8 +25,8 @@ env:
   DEPLOYMENT_FOLDER: gke-projects/$GCP_PROJECT_ID/dev/deployments/
   IMAGE_NAME: $GCP_PROJECT_ID/$GITHUB_REPO_NAME
   REGISTRY_HOSTNAME: gcr.io
-  GIT_COMMITTER_NAME: 'Pizza Dog'
-  GIT_COMMITTER_EMAIL: 'dev@tributelabs.xyz'
+  GIT_COMMITTER_NAME: "Pizza Dog"
+  GIT_COMMITTER_EMAIL: "dev@tributelabs.xyz"
   ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
@@ -56,10 +57,10 @@ jobs:
           docker push "$REGISTRY_HOSTNAME"/${{ env.IMAGE_NAME }}:"$TAG"
           docker tag "$REGISTRY_HOSTNAME"/${{ env.IMAGE_NAME }}:"$TAG" "$REGISTRY_HOSTNAME"/${{ env.IMAGE_NAME }}:${{ env.DEPLOYMENT_BRANCH }}
           docker push "$REGISTRY_HOSTNAME"/${{ env.IMAGE_NAME }}:${{ env.DEPLOYMENT_BRANCH }}
-          
+
       - name: Checkout openlawteam/infrastructure repo
         uses: actions/checkout@v2
-        with: 
+        with:
           repository: ${{ env.INFRA_REPO }}
           token: ${{ secrets.PAT_OLBOT_PUB_REPOS_RW }}
 
@@ -81,4 +82,3 @@ jobs:
           repository: ${{ env.INFRA_REPO }}
           github_token: ${{ secrets.PAT_OLBOT_PUB_REPOS_RW }}
           branch: master
-            

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
 
 env:
   ## Required Env Vars
@@ -20,8 +21,8 @@ env:
   DEPLOYMENT_FOLDER: gke-projects/$GCP_PROJECT_ID/prod/deployments/
   IMAGE_NAME: $GCP_PROJECT_ID/$GITHUB_REPO_NAME
   REGISTRY_HOSTNAME: gcr.io
-  GIT_COMMITTER_NAME: 'Pizza Dog'
-  GIT_COMMITTER_EMAIL: 'dev@tributelabs.xyz'
+  GIT_COMMITTER_NAME: "Pizza Dog"
+  GIT_COMMITTER_EMAIL: "dev@tributelabs.xyz"
   ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
@@ -52,10 +53,10 @@ jobs:
           docker push "$REGISTRY_HOSTNAME"/${{ env.IMAGE_NAME }}:"$TAG"
           docker tag "$REGISTRY_HOSTNAME"/${{ env.IMAGE_NAME }}:"$TAG" "$REGISTRY_HOSTNAME"/${{ env.IMAGE_NAME }}:${{ env.DEPLOYMENT_BRANCH }}
           docker push "$REGISTRY_HOSTNAME"/${{ env.IMAGE_NAME }}:${{ env.DEPLOYMENT_BRANCH }}
-          
+
       - name: Checkout openlawteam/infrastructure repo
         uses: actions/checkout@v2
-        with: 
+        with:
           repository: ${{ env.INFRA_REPO }}
           token: ${{ secrets.PAT_OLBOT_PUB_REPOS_RW }}
 

--- a/.github/workflows/prettier-lint.yml
+++ b/.github/workflows/prettier-lint.yml
@@ -3,6 +3,7 @@ name: Prettier Lint
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   lint-style:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,6 +3,7 @@ name: Unit Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   tests:


### PR DESCRIPTION


🧹 **Chores done**

- Adds [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) to `on:` list in GH Action files to provide the option to trigger builds from the CLI, REST or, UI
 