### PR TITLE
removes remaining references in tests to `http://docker-host`

### DIFF
--- a/src/services/snapshotHub/legacyTributeDraftResolver.unit.test.ts
+++ b/src/services/snapshotHub/legacyTributeDraftResolver.unit.test.ts
@@ -14,8 +14,7 @@ describe('legacyTributeDraftResolver unit tests', () => {
   test('should return a legacy Tribute snapshot hub draft', async () => {
     expect(
       await legacyTributeDraftResolver({
-        // @see `docker-host` in `docker-compose.dev.yml`
-        apiBaseURL: 'http://docker-host:8081/api',
+        apiBaseURL: 'http://localhost:8081/api',
         proposalID: BYTES32_FIXTURE,
         space: 'tribute',
       })
@@ -37,8 +36,7 @@ describe('legacyTributeDraftResolver unit tests', () => {
 
     expect(
       await legacyTributeDraftResolver({
-        // @see `docker-host` in `docker-compose.dev.yml`
-        apiBaseURL: 'http://docker-host:8081/api',
+        apiBaseURL: 'http://localhost:8081/api',
         proposalID: BYTES32_FIXTURE,
         space: 'tribute',
       })
@@ -53,8 +51,7 @@ describe('legacyTributeDraftResolver unit tests', () => {
 
     expect(
       await legacyTributeDraftResolver({
-        // @see `docker-host` in `docker-compose.dev.yml`
-        apiBaseURL: 'http://docker-host:8081/api',
+        apiBaseURL: 'http://localhost:8081/api',
         proposalID: BYTES32_FIXTURE,
         space: 'tribute',
       })
@@ -79,8 +76,7 @@ describe('legacyTributeDraftResolver unit tests', () => {
 
     expect(
       await legacyTributeDraftResolver({
-        // @see `docker-host` in `docker-compose.dev.yml`
-        apiBaseURL: 'http://docker-host:8081/api',
+        apiBaseURL: 'http://localhost:8081/api',
         proposalID: BYTES32_FIXTURE,
         space: 'tribute',
       })

--- a/src/services/snapshotHub/legacyTributeProposalResolver.unit.test.ts
+++ b/src/services/snapshotHub/legacyTributeProposalResolver.unit.test.ts
@@ -51,7 +51,6 @@ describe('legacyTributeProposalResolver unit tests', () => {
 
     expect(
       await legacyTributeProposalResolver({
-        // @see `docker-host` in `docker-compose.dev.yml`
         apiBaseURL: 'http://localhost:8081/api',
         proposalID: BYTES32_FIXTURE,
         space: 'tribute',
@@ -78,7 +77,6 @@ describe('legacyTributeProposalResolver unit tests', () => {
 
     expect(
       await legacyTributeProposalResolver({
-        // @see `docker-host` in `docker-compose.dev.yml`
         apiBaseURL: 'http://localhost:8081/api',
         proposalID: BYTES32_FIXTURE,
         space: 'tribute',


### PR DESCRIPTION
🧹 **Chores done**

- Removes remaining references to `docker-host` in tests as it was causing `msw` to fail in CI
