### PR TITLE
Decimal support for `/fund`

### DIFF
--- a/prisma/migrations/20220513131502_/migration.sql
+++ b/prisma/migrations/20220513131502_/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "fund_address_poll" ALTER COLUMN "amountUSDC" SET DEFAULT 0,
+ALTER COLUMN "amountUSDC" SET DATA TYPE DECIMAL(65,2);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ model BuyNFTPoll {
   name            String   @db.VarChar(255)
   contractAddress String   @db.VarChar(255)
   tokenID         String   @db.VarChar(255)
+  // 78 = total decimal digits length, and 0 = number of digits stored to the right of the decimal point
   amountWEI       Decimal  @default(0) @db.Decimal(78, 0)
   processed       Boolean  @default(false) @db.Boolean
   voteThreshold   Int      @default(0) @db.Integer
@@ -70,7 +71,8 @@ model FundAddressPoll {
   createdAt       DateTime @default(now())
   purpose         String   @db.VarChar(255)
   addressToFund   String   @db.VarChar(255)
-  amountUSDC      Int      @default(0) @db.Integer
+  // 65 = total decimal digits length, and 2 = number of digits stored to the right of the decimal point
+  amountUSDC      Decimal  @default(0) @db.Decimal(65, 2)
   processed       Boolean  @default(false) @db.Boolean
   voteThreshold   Int      @default(0) @db.Integer
   upvoteCount     Int      @default(0) @db.Integer

--- a/src/applications/tribute-tools/handlers/cancelPollHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/cancelPollHandler.unit.test.ts
@@ -54,7 +54,7 @@ describe('cancelPollHandler unit tests', () => {
   const DEFAULT_FUND_DB_ENTRY: FundAddressPoll = {
     actionMessageID: '123456789',
     addressToFund: ETH_ADDRESS_FIXTURE,
-    amountUSDC: 50000,
+    amountUSDC: new Prisma.Decimal(50000.55),
     channelID: '886976610018934824',
     createdAt: new Date(0),
     guildID: GUILD_ID_FIXTURE,

--- a/src/applications/tribute-tools/handlers/confirmCancelPollHandler.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/confirmCancelPollHandler.unit.test.ts
@@ -53,7 +53,7 @@ describe('confirmCancelPollHandler unit tests', () => {
   const DEFAULT_FUND_DB_ENTRY: FundAddressPoll = {
     actionMessageID: '123456789',
     addressToFund: ETH_ADDRESS_FIXTURE,
-    amountUSDC: 50000,
+    amountUSDC: new Prisma.Decimal(50000.55),
     channelID: '886976610018934824',
     createdAt: new Date(0),
     guildID: GUILD_ID_FIXTURE,

--- a/src/applications/tribute-tools/handlers/notifyPollTxStatus.unit.test.ts
+++ b/src/applications/tribute-tools/handlers/notifyPollTxStatus.unit.test.ts
@@ -59,7 +59,7 @@ describe('notifyPollTxStatus unit tests', () => {
   const FUND_DB_ENTRY: FundAddressPoll = {
     actionMessageID: '987654321',
     addressToFund: ETH_ADDRESS_FIXTURE,
-    amountUSDC: 123,
+    amountUSDC: new Prisma.Decimal(123.55),
     channelID: '123456789',
     createdAt: new Date(0),
     guildID: GUILD_ID_FIXTURE,


### PR DESCRIPTION
Fixes #140 

✨ **Updates**

- DB Migration: sets `fund_address_poll`->`amountUSDC` to `DECIMAL(65,2)`
- Changes Discord slash command option type `amount_in_usdc` from `INTEGER` to `NUMBER`


